### PR TITLE
Adding participation grade during annotation_create

### DIFF
--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -128,6 +128,8 @@ def save_session(request, **kwargs):
         "roles": ["hx_roles", []],
         "is_staff": ["is_staff", False],
         "is_instructor": ["is_instructor", False],
+        "is_graded": ['is_graded', False],
+        "lti_params": ['lti_params', None]
     }
     
     for k in kwargs:


### PR DESCRIPTION
@arthurian Take a look at this when you get the chance.

The only thing it requires is that the LTI consumer sends in an ```lis_outcome_service_url``` parameter. 