### PR TITLE
quick hotfix for an Annotator check I wrote stupidly

### DIFF
--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -480,7 +480,7 @@
             }
         });
 
-        if (Annotator !== undefined && Annotator.prototype.isPrototypeOf(AController.annotationCore.annotation_tool)) {
+        if (window.Annotator !== undefined && window.Annotator.prototype.isPrototypeOf(AController.annotationCore.annotation_tool)) {
             console.log('it was all defined. problem is probably not here.');
             AController.annotationCore.annotation_tool.subscribe('annotationHidden', function(annotationId) {
                 jQuery('.annotationItem.item-' + annotationId).hide();


### PR DESCRIPTION
Wrote a stupid line of code. It caused issues in the Image Annotation Tool because it does not use Annotator. This should fix it.