### PR TITLE
Bugfix/username

### DIFF
--- a/hx_lti_initializer/admin.py
+++ b/hx_lti_initializer/admin.py
@@ -10,7 +10,8 @@ from hx_lti_initializer.models import LTIProfile, LTICourse
 
 
 class LTIProfileAdmin(admin.ModelAdmin):
-    pass
+    list_display = ('id', 'user', 'scope', 'anon_id', 'name', 'roles')
+    ordering = ('user', 'scope', 'anon_id', 'name', 'roles')
 
 
 class LTICourseAdmin(admin.ModelAdmin):

--- a/hx_lti_initializer/forms.py
+++ b/hx_lti_initializer/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.db.models import Q
 from hx_lti_initializer.models import LTICourse, LTIProfile
 from hx_lti_assignment.models import Assignment
 
@@ -11,10 +12,10 @@ class CourseForm(forms.ModelForm):
         self.fields['course_admins'].queryset = self.get_course_admins()
 
     def get_course_admins(self):
-        filters = {}
+        queryset = LTIProfile.objects.all()
         if self._user_scope:
-            filters['scope'] = self._user_scope
-        return LTIProfile.objects.filter(**filters).select_related('user').order_by('name', 'user__username')
+            queryset = queryset.filter(Q(scope=self._user_scope)|Q(scope__isnull=True))
+        return queryset.select_related('user').order_by('name', 'user__username')
 
     class Meta:
         model = LTICourse

--- a/hx_lti_initializer/forms.py
+++ b/hx_lti_initializer/forms.py
@@ -6,11 +6,15 @@ from hx_lti_assignment.models import Assignment
 class CourseForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
+        self._user_scope = kwargs.pop('user_scope', None)
         super(CourseForm, self).__init__(*args, **kwargs)
         self.fields['course_admins'].queryset = self.get_course_admins()
 
     def get_course_admins(self):
-        return LTIProfile.objects.select_related('user').order_by('user__first_name', 'user__last_name', 'user__username')
+        filters = {}
+        if self._user_scope:
+            filters['scope'] = self._user_scope
+        return LTIProfile.objects.filter(**filters).select_related('user').order_by('name', 'user__username')
 
     class Meta:
         model = LTICourse

--- a/hx_lti_initializer/migrations/0013_ltiprofile_name.py
+++ b/hx_lti_initializer/migrations/0013_ltiprofile_name.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hx_lti_initializer', '0012_auto_20151008_1650'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ltiprofile',
+            name='name',
+            field=models.CharField(max_length=255, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/hx_lti_initializer/migrations/0014_auto_20160318_1433.py
+++ b/hx_lti_initializer/migrations/0014_auto_20160318_1433.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hx_lti_initializer', '0013_ltiprofile_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ltiprofile',
+            name='user',
+            field=models.ForeignKey(related_name='annotations_user_profile', to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/hx_lti_initializer/migrations/0015_ltiprofile_scope.py
+++ b/hx_lti_initializer/migrations/0015_ltiprofile_scope.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hx_lti_initializer', '0014_auto_20160318_1433'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ltiprofile',
+            name='scope',
+            field=models.CharField(max_length=1024, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/hx_lti_initializer/models.py
+++ b/hx_lti_initializer/models.py
@@ -52,21 +52,6 @@ class LTIProfile(models.Model):
         return anon_id
 
 
-def user_post_save(sender, instance, created, **kwargs):
-    """
-    This function will create an LTIProfile object.
-    Then save the user object to it so that they are interconnected.
-    """
-
-    if created is True:
-        p = LTIProfile()
-        p.user = instance
-        p.save()
-
-# this function will then connect the function created above so that a
-# matching LTIProfile object is created after any User object is created.
-post_save.connect(user_post_save, sender=User)
-
 
 class LTICourse(models.Model):
     """

--- a/hx_lti_initializer/models.py
+++ b/hx_lti_initializer/models.py
@@ -25,6 +25,7 @@ class LTIProfile(models.Model):
         related_name='annotations_user_profile',
         null=True,
     )
+
     # saves the list of roles attached to that user
     roles = models.CharField(
         max_length=255,
@@ -38,9 +39,13 @@ class LTIProfile(models.Model):
         max_length=255, blank=True, null=True
     )
 
+    name = models.CharField(
+        max_length=255, blank=True, null=True
+    )
+
     def __unicode__(self):
         """ When asked to print itself, this object will print the username """
-        return self.user.username
+        return self.name or self.user.username
 
     class Meta:
         """ The name of this section within the admin site """

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -87,7 +87,7 @@ def initialize_lti_tool_provider(req):
     return provider
 
 def create_new_user(user_id=None, roles=None, username=None, **kwargs):
-    debug_printer('DEBUG - Creating User and LTIPRofile for anon_id=%s and roles=%s' % (anon_id, roles))
+    debug_printer('DEBUG - Creating User and LTIPRofile for anon_id=%s and roles=%s' % (user_id, roles))
     if user_id is None or roles is None:
         raise Exception("Missing required user_id and/or roles to create new user")
 
@@ -103,16 +103,16 @@ def create_new_user(user_id=None, roles=None, username=None, **kwargs):
     except User.DoesNotExist:
         user = User.objects.create_user(username)
 
-    user.email = kwargs.get('email', None)
-    user.first_name = kwargs.get('first_name', None)
-    user.last_name = kwargs.get('last_name', None)
+    user.email = kwargs.get('email', '')
+    user.first_name = kwargs.get('first_name', '')
+    user.last_name = kwargs.get('last_name', '')
     user.is_superuser = False
     user.is_staff = set(roles) & set(settings.ADMIN_ROLES)
     user.set_unusable_password()
     user.save()
     
     lti_profile.user = user
-    lti_profile.save()
+    lti_profile.save(update_fields=['user'])
     
     debug_printer('DEBUG - User:%s was just created with LTIProfile:%s' % (user.id, lti_profile.id))
     return user, lti_profile

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -110,6 +110,8 @@ def create_new_user(anon_id=None, username=None, display_name=None, roles=None, 
         user.is_staff = set(roles) & set(settings.ADMIN_ROLES)
         user.set_unusable_password()
         user.save()
+    except User.MultipleObjectsReturned:
+        user = User.objects.filter(username=username).order_by('id')[0]
     
     lti_profile.user = user
     lti_profile.save(update_fields=['user'])

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -5,6 +5,7 @@ helpful elsewhere.
 import django.shortcuts
 from urlparse import urlparse
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from abstract_base_classes.target_object_database_api import *
 from models import *
 from django.conf import settings
@@ -86,33 +87,41 @@ def initialize_lti_tool_provider(req):
 
     return provider
 
-def create_new_user(user_id=None, name=None, roles=None):
-    debug_printer('DEBUG - Creating new user user_id=%s, name=%s, roles=%s' % (user_id, name, roles))
-    if user_id is None or name is None or roles is None:
-        raise Exception("Missing required parameters: user_id, name, roles")
+@transaction.atomic
+def create_new_user(anon_id=None, username=None, display_name=None, roles=None, scope=None):
+    debug_printer('DEBUG - Creating new user with parameters: anon_id=%s, username=%s, display_name=%s, roles=%s' % (anon_id, username, display_name, roles))
+    if anon_id is None or display_name is None or roles is None:
+        raise Exception("Missing required parameters: anon_id, display_name, roles")
 
-    lti_profile = LTIProfile(anon_id=user_id)
-    lti_profile.name = name
+    lti_profile = LTIProfile(anon_id=anon_id)
+    lti_profile.name = display_name
     lti_profile.roles = ",".join(roles)
+    lti_profile.scope = scope
     lti_profile.save()
 
-    username = 'profile:{id}'.format(id=lti_profile.id)
-    user = User.objects.create_user(username)
-    user.is_superuser = False
-    user.is_staff = set(roles) & set(settings.ADMIN_ROLES)
-    user.set_unusable_password()
-    user.save()
+    if not username:
+        username = 'profile:{id}'.format(id=lti_profile.id)
+
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        user = User.objects.create_user(username)
+        user.is_superuser = False
+        user.is_staff = set(roles) & set(settings.ADMIN_ROLES)
+        user.set_unusable_password()
+        user.save()
     
     lti_profile.user = user
     lti_profile.save(update_fields=['user'])
     
-    debug_printer('DEBUG - User=%s associated with LTIProfile=%s' % (user.id, lti_profile.id))
+    debug_printer('DEBUG - Created LTIProfile.%s associated with User.%s' % (lti_profile.id, user.id))
     return user, lti_profile
 
 def save_session(request, **kwargs):
     session_key_for = {
         "user_id": ["hx_user_id", None],
         "user_name": ["hx_user_name", None],
+        "user_scope": ["hx_user_scope", None],
         "context_id": ["hx_context_id", None],
         "course_id": ["hx_lti_course_id", None],
         "course_name": ["course_name", None],

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -72,7 +72,7 @@ def launch_lti(request):
     else:
         tool_consumer_instance_guid = get_lti_value('tool_consumer_instance_guid', tool_provider)
         if tool_consumer_instance_guid:
-            user_scope = "domain:%s" % tool_consumer_instance_guid
+            user_scope = "consumer:%s" % tool_consumer_instance_guid
     debug_printer("DEBUG - user scope is: %s" % user_scope)
 
     # default to student

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -60,6 +60,21 @@ def launch_lti(request):
     course = get_lti_value(settings.LTI_COURSE_ID, tool_provider)
     debug_printer('DEBUG - Found course being accessed: %s' % course)
 
+    # This is where we identify the "scope" of the LTI user_id (anon_id), meaning
+    # the scope in which the identifier is unique. In canvas this is the domain instance,
+    # where as in edX this is the course instance.
+    #
+    # The idea is that the combination of the LTI user_id (anon_id) and scope should be
+    # globally unique.
+    user_scope = None
+    if settings.ORGANIZATION == "HARVARDX":
+        user_scope = "course:%s" % course
+    else:
+        tool_consumer_instance_guid = get_lti_value('tool_consumer_instance_guid', tool_provider)
+        if tool_consumer_instance_guid:
+            user_scope = "domain:%s" % tool_consumer_instance_guid
+    debug_printer("DEBUG - user scope is: %s" % user_scope)
+
     # default to student
     request.session['is_instructor'] = False
 
@@ -69,16 +84,23 @@ def launch_lti(request):
     roles = get_lti_value(settings.LTI_ROLES, tool_provider)
     debug_printer("DEBUG - user logging in with roles: " + str(roles))
 
-    display_user_name = get_lti_value('lis_person_name_full', tool_provider)
-    if not display_user_name:
-        display_user_name = get_lti_value('lis_person_sourcedid', tool_provider)
 
-    lti_username = get_lti_value('lis_person_sourcedid', tool_provider)
-    if not lti_username:
+    # This is the name that we will show on the UI
+    display_name = get_lti_value('lis_person_name_full', tool_provider)
+    if not display_name:
+        display_name = get_lti_value('lis_person_sourcedid', tool_provider)
+    debug_printer("DEBUG - user name: " + display_name)
+
+    # This is the unique identifier for the person in the source system
+    # In canvas this would be the SIS user id, in edX the registered username
+    external_user_id = get_lti_value('lis_person_sourcedid', tool_provider)
+    
+    # This handles the rare case in which we have neither display name nor external user id
+    if not display_name and not external_user_id:
         try:
             lti_profile = LTIProfile.objects.get(anon_id=str(course))
-            lti_username = lti_profile.user.username
             roles = ['student']
+            display_name = lti_profile.user.username
             messages.warning(request, "edX still has not fixed issue with no user_id in studio.")
             messages.error(request, "Warning: you are logged in as a Preview user. Please view this in live to access admin hub.")
         except:
@@ -99,14 +121,15 @@ def launch_lti(request):
         except LTIProfile.DoesNotExist:
             # if it's a new user (profile doesn't exist), set up and save a new LTI Profile
             debug_printer('DEBUG - LTI Profile NOT found. New User to be created.')
-            user, lti_profile = create_new_user(user_id=user_id, name=display_user_name, roles=roles)
+            user, lti_profile = create_new_user(anon_id=user_id, username=external_user_id, display_name=display_name, roles=roles, scope=user_scope)
             # log the user into the Django backend
         lti_profile.user.backend = 'django.contrib.auth.backends.ModelBackend'
         login(request, lti_profile.user)
         save_session(
             request,
             user_id=user_id,
-            user_name=display_user_name,
+            user_name=display_name,
+            user_scope=user_scope,
             context_id=course,
             roles=roles,
             is_staff=True
@@ -128,7 +151,8 @@ def launch_lti(request):
         save_session(
             request,
             user_id=user_id,
-            user_name=display_user_name,
+            user_name=display_name,
+            user_scope=user_scope,
             context_id=course,
             roles=roles,
             is_staff=False
@@ -162,11 +186,11 @@ def launch_lti(request):
             messages.warning(request, message_error)
 
             # create and save a new course for the instructor, with a default name of their canvas course's name
-            course_object = LTICourse.create_course(course, lti_profile)
-            create_new_user(username='preview' + str(course).replace(':', ''), user_id=str(course), roles=['student'])
+            context_title = None
             if get_lti_value('context_title', tool_provider) is not None:
-                course_object.course_name = get_lti_value('context_title', tool_provider)
-                course_object.save()
+                context_title = get_lti_value('context_title', tool_provider)
+            course_object = LTICourse.create_course(course, lti_profile, name=context_title)
+            create_new_user(anon_id=str(course), username='preview:%s' % course_object.id, display_name="Preview %s" % str(course_object), roles=['student'], scope=user_scope)
 
             # save the course name to the session so it auto-populate later.
             save_session(
@@ -202,6 +226,7 @@ def launch_lti(request):
 @login_required
 def edit_course(request, id):
     course = get_object_or_404(LTICourse, pk=id)
+    user_scope = request.session.get('hx_user_scope', None)
     if request.method == "POST":
         form = CourseForm(request.POST, instance=course)
         if form.is_valid():
@@ -216,7 +241,7 @@ def edit_course(request, id):
         else:
             raise PermissionDenied()
     else:
-        form = CourseForm(instance=course)
+        form = CourseForm(instance=course, user_scope=user_scope)
     return render(
         request,
         'hx_lti_initializer/edit_course.html',

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -96,9 +96,8 @@ def launch_lti(request):
             debug_printer('DEBUG - LTI Profile was found via anonymous id.')
         except LTIProfile.DoesNotExist:
             # if it's a new user (profile doesn't exist), set up and save a new LTI Profile
-            debug_printer('DEBUG - LTI Profile not found. New User to be created.')
-            debug_printer("DEBUG - Creating a user with role(s): " + str(roles))
-            user, lti_profile = create_new_user(lti_username, user_id, roles)
+            debug_printer('DEBUG - LTI Profile NOT found. New User to be created.')
+            user, lti_profile = create_new_user(user_id=user_id, roles=roles)
             # log the user into the Django backend
         lti_profile.user.backend = 'django.contrib.auth.backends.ModelBackend'
         login(request, lti_profile.user)
@@ -162,7 +161,7 @@ def launch_lti(request):
 
             # create and save a new course for the instructor, with a default name of their canvas course's name
             course_object = LTICourse.create_course(course, lti_profile)
-            create_new_user('preview' + str(course).replace(':', ''), str(course), ['student'])
+            create_new_user(username='preview' + str(course).replace(':', ''), user_id=str(course), roles=['student'])
             if get_lti_value('context_title', tool_provider) is not None:
                 course_object.course_name = get_lti_value('context_title', tool_provider)
                 course_object.save()

--- a/target_object_database/views.py
+++ b/target_object_database/views.py
@@ -13,8 +13,11 @@ from hx_lti_initializer.utils import debug_printer
 def get_course_id(request):
 	return request.session['hx_lti_course_id']
 
+def get_lti_profile(request):
+    return LTIProfile.objects.get(anon_id=request.session['hx_user_id'])
+
 def get_lti_profile_id(request):
-    lti_profile = LTIProfile.objects.get(user=request.user)
+    lti_profile = get_lti_profile(request)
     return lti_profile.id
 
 def open_target_object(request, collection_id, target_obj_id):


### PR DESCRIPTION
@lduarte1991 At long last, here's the PR I've been promising. It's a little more comprehensive than the band-aid fix I was originally contemplating, but hopefully not too destructive. Anyway, here's what I was thinking for resolving the duplicate user object issue. I'm going to recap the problem statement we discussed offline for posterity (or anyone else looking at this).

**Problem Statement**
The situation we have right now is duplicate `User` objects. Every time a new profile is created, a new user object is created, even if a user object already exists with the same username. This PR attempts to solve that problem by only creating one user and then relating profiles back to it as they are created.

Here's what happens when an instructor registered in edX or canvas as "foo" uses the tool:

```
EdX(edx.org):
   - Course Context: FooX
        - User(id=1, username=foo) + LTIProfile(id=100, anon_id=222, user_id=1)
   - Course Context: BarX
        - User(id=2, username=foo) + LTIProfile(id=200, anon_id=333, user_id=2)
   - Course Context: ZedX
        - User(id=3, username=foo) + LTIProfile(id=300, anon_id=444, user_id=3)

Canvas(one.instructure.com):
   - User(id=1, username=foo) + LTIProfile(id=100, anon_id=111, user_id=1)
   - Course Context: Foo
   - Course Context: Bar
   - Course Context: Zed
Canvas(two.instructure.com):
   - User(id=2, username=foo) + LTIProfile(id=200, anon_id=222, user_id=2)
   - Course Context: Foo
   - Course Context: Bar
   - Course Context: Zed
```

The changes in this PR should result in something more like this:

```
EdX(edx.org):
   - User(id=1, username=foo)
   - Course Context: FooX
        - LTIProfile(id=100, anon_id=222, user_id=1)
   - Course Context: BarX
        - LTIProfile(id=200, anon_id=333, user_id=1)
   - Course Context: ZedX
        - LTIProfile(id=300, anon_id=444, user_id=1)

User(id=1, username=HUID)
Canvas(one.instructure.com):
   - LTIProfile(id=100, anon_id=111, user_id=1)
   - Course Context: Foo
   - Course Context: Bar
   - Course Context: Zed
Canvas(two.instructure.com):
   - LTIProfile(id=200, anon_id=222, user_id=1)
   - Course Context: Foo
   - Course Context: Bar
   - Course Context: Zed
```


**Migrations**
- Added the following fields to LTIProfile: *name* and *scope*.
    - *name* is the display name that can appear on the UI. Right now, the only place is on the edit course page where you can add admins. This is the field that will show instead of the user object's *username* (if it has a value). For backwards compatibility, if the profile has no *name*, then it will use the user objects' *username*.
    - *scope* defines the area in which the *anon_id* can be considered unique by the tool. For edX, this is just the course context, if I understand correctly. For Canvas, however, this is the entire domain/instance. In either case, the combination of the *anon_id* and *scope* should uniquely identify that profile. The *scope* can be used to limit what profiles are displayed as potential admin candidates for the course.
- Dropped the uniqueness constraint on the *user* relationship by changing it to a **ForeignKey**. This  makes it official that there's a many-to-one  relationship between profiles and user objects.

**Code Changes**
This is a brief overview of the changes, but of course, you can read the diff below.
- I refactored the `utils.create_new_user()` function to reflect the above changes. The caller should pass in a *username* that can be considered globally unique on the platform. For edX, this is assumed to be the registered username, and for Canvas this is the SIS id (i.e. huid, xid, etc). Once the user object is created for the first time with that username, it will associate any subsequent profiles with it. Since you already have multiple user objects with the same username in edX, I added some logic to reuse the first user object (ordered by `user.id`). This might not be the best way to handle that, but since the data is already kind of corrupted, I'm not sure what the best course of action is.
- I refactored the `views.launch_lti()` function to pass the required parameters when creating new users. There's only two places where it is called. The second instance of where this is called has to do with creating the "preview" user to work around the issue in edX Studio.
- I refactored the `models.LTICourse.create_course()` method to set the course name properly and pulled out the method to add admins.

**Comments**
What do you think of this approach to the problem? I made a number of assumptions as to how we can implement this in a way that preserves backwards compatibility and doesn't require extensive data cleanup (although that would be good to do at some point). 

Do you see anything that could cause problems in edX? Is there a better approach or some things you think we should change? I'm open to any suggestions, this is just a starting point. 