### PR TITLE
Multiple profiles fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ secure.py
 http_static
 production.py
 reports
+*-annotation-list.json

--- a/hx_lti_initializer/migrations/0016_auto_20160401_2054.py
+++ b/hx_lti_initializer/migrations/0016_auto_20160401_2054.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hx_lti_initializer', '0015_ltiprofile_scope'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LTICourseAdmin',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('admin_unique_identifier', models.CharField(max_length=255)),
+                ('new_admin_course_id', models.CharField(max_length=255)),
+            ],
+            options={
+                'verbose_name': 'Pending Admin',
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterUniqueTogether(
+            name='lticourseadmin',
+            unique_together=set([('admin_unique_identifier', 'new_admin_course_id')]),
+        ),
+    ]

--- a/hx_lti_initializer/models.py
+++ b/hx_lti_initializer/models.py
@@ -173,4 +173,28 @@ class LTICourse(models.Model):
             self.course_users.add(lti_profile)
             self.save()
         return self
-        
+
+
+class LTICourseAdmin(models.Model):
+
+    admin_unique_identifier = models.CharField(
+        max_length=255
+    )
+
+    new_admin_course_id = models.CharField(
+        max_length=255
+    )
+
+    class Meta:
+        verbose_name = _("Pending Admin")
+        unique_together = ("admin_unique_identifier", "new_admin_course_id")
+
+    def __unicode__(self):
+        """
+        """
+        return u"%s for course %s" % (self.admin_unique_identifier, self.new_admin_course_id)
+
+    def __str__(self):
+        """
+        """
+        return "%s for course %s" % (self.admin_unique_identifier, self.new_admin_course_id)

--- a/hx_lti_initializer/templates/hx_lti_initializer/edit_course.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/edit_course.html
@@ -1,4 +1,5 @@
 {% extends 'hx_lti_initializer/base.html' %}
+{% load possible_admins %}
 {% load bootstrap3 %}
 
 {# Load CSS and JavaScript #}
@@ -12,18 +13,43 @@
 	<h3>Edit Course</h3>
 	<form method="POST" class="post-form">{% csrf_token %}
 		{{ form.non_field_errors }}
+		{{ form.errors }}
 		<div class="form-group">
 			<label for="id_course_name">Course name:</label> 
 			<input id="id_course_name" maxlength="255" name="course_name" class="form-control" type="text" value="{{form.course_name.value}}">
 		</div>
 		<div class="form-group">
+			<label for="id_select_existing_user">Add a new admin from existing user:</label>
+			<select class="form-control selectpicker" data-live-search="true" multiple id="id_select_existing_user" name="select_existing_user">
+				{% for selected, name in form.course_admins.value|list_of_possible_admins %}
+					<option value="{{name}}" {% if selected %} selected {% endif %}> {{name}} </option>
+				{% endfor %}
+			</select>
+			<label for="id_new_admin_list">Add new admins via unique id (edX = username, canvas = HUID):</label>
+			<input type="text" maxlength="255" name="new_admin_list" class="form-control" id="id_new_admin_list">
+			<p class="help">If adding multiple users, separate them with commas, not spaces.</p>
+			<label for="pending_admins">Pending Admins (will be added as course admins next time they log in):</label> {% if pending %}
+			{% for ad in pending %}
+				{{ad.admin_unique_identifier}},
+			{% endfor %}
+			{% else %} None {% endif %}
+		</div>
+		 <div class="form-group hidden">
+			<label for="id_course_admins">Course admins:</label> 
+			<select class="form-control selectpicker" data-live-search="true" multiple id="id_course_admins" name="course_admins">
+				{% for id,choice in form.fields.course_admins.choices %}
+				<option value="{{ id }}" {% if id in form.course_admins.value %} selected {% endif %}>{{ choice }}</option>
+				{% endfor %}
+			</select> 
+		</div>
+		<!-- <div class="form-group">
 			<label for="id_course_admins">Course admins:</label> 
 			<select class="form-control selectpicker" data-live-search="true" multiple id="id_course_admins" name="course_admins" role="listbox">
 				{% for id,choice in form.fields.course_admins.choices %}
 				<option value="{{ id }}" aria-checked={% if id in form.course_admins.value %}"true" selected {% else %}"false"{% endif %} role="option">{{ choice }}</option>
 				{% endfor %}
 			</select> 
-		</div>
+		</div> -->
 		<!-- TODO: Add example of how to use-->
 		<div class="form-group">
 			<label for="id_course_external_css_default">External CSS Default:</label> 

--- a/hx_lti_initializer/templatetags/possible_admins.py
+++ b/hx_lti_initializer/templatetags/possible_admins.py
@@ -1,0 +1,22 @@
+from django.template import Library
+from hx_lti_initializer.models import LTIProfile
+
+register = Library()
+
+
+@register.filter_function
+def list_of_possible_admins(already_in_course):
+    list_of_usernames_already_in_course = []
+    list_of_unique_names = []
+    result = []
+
+    for profile in LTIProfile.objects.all():
+        if profile.id in already_in_course:
+            list_of_usernames_already_in_course.append(profile.user.username)
+        if profile.user.username not in list_of_unique_names and "preview:" not in profile.user.username:
+            list_of_unique_names.append(profile.user.username)
+
+    for name in list_of_unique_names:
+        result.append((name in list_of_usernames_already_in_course, name))
+
+    return result


### PR DESCRIPTION
@arthurian Take a look at this. Basically now the Edit Course Settings page will only show you unique usernames in the dropdown list which you can select. There's also a textfield that allows you to input an "expected" administrator so even if they haven't logged in you can pre-empt them and add them as admin next time they log in.

I think you should take a look and tell me what the appropriate changes would be for ATG. I'll point out what I think may be areas were we could diverge below. 

Basically this creates a new table where "pending" admins get added. That means allows you to select the appropriate profile since they will be officially added as admins once they log in. 