### PR TITLE
Import/Export Annotations

### DIFF
--- a/hx_lti_initializer/static/DashboardController.js
+++ b/hx_lti_initializer/static/DashboardController.js
@@ -82,6 +82,7 @@
 				controller: self,
 				default_tab: self.initOptions.default_tab,
 				show_instructor_tab: self.initOptions.show_instructor_tab,
+				is_instructor: self.initOptions.is_instructor === "True",
 			});
 		});
 

--- a/hx_lti_initializer/static/DashboardController.js
+++ b/hx_lti_initializer/static/DashboardController.js
@@ -94,16 +94,19 @@
 			self.endpoint.queryDatabase({
 				"user_id": undefined,
 			}, self.initOptions.pagination, self.initOptions.media);
+			self.viewer.removePrintButton();
 		});
 		jQuery('#mynotes').click(function (e){
 			self.endpoint.queryDatabase({
 				"user_id": self.initOptions.user_id,
 			}, self.initOptions.pagination, self.initOptions.media);
+			self.viewer.addPrintButton();
 		});
 		jQuery('#instructor').click(function (e){
 			self.endpoint.queryDatabase({
 				"user_id": self.initOptions.instructors,
 			}, self.initOptions.pagination, self.initOptions.media);
+			self.viewer.removePrintButton();
 		});
 		
 		jQuery('button#search-submit').click(function (e) {

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -111,7 +111,9 @@
     };
 
     $.DashboardView.prototype.addPrintButton = function() {
-        jQuery('.handleAnnotations').show();
+        if (this.initOptions.is_instructor) {
+            jQuery('.handleAnnotations').show();
+        }
     };
 
     $.DashboardView.prototype.removePrintButton = function() {

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -8,7 +8,8 @@
                 "annotationModal",
                 "replyItem",
                 "editReplyItem",
-                'annotationInstructions',
+                "annotationInstructions",
+                "importItems",
             ],
             TEMPLATES: {},
             suffix: "side",
@@ -105,8 +106,78 @@
         return jQuery("button.user-filter.disabled");
     };
 
-    $.DashboardView.prototype.clearDashboard = function(){
+    $.DashboardView.prototype.clearDashboard = function() {
         jQuery('.annotationsHolder').html('');
+    };
+
+    $.DashboardView.prototype.addPrintButton = function() {
+        jQuery('.handleAnnotations').show();
+    };
+
+    $.DashboardView.prototype.removePrintButton = function() {
+        jQuery('.handleAnnotations').hide();
+    };
+
+    $.DashboardView.prototype.printAnnotations = function() {
+        var annotations = this.initOptions.controller.endpoint.annotationsMasterList;
+        var html = "<style>table, th, td { border: 1px solid black;} table { border-collapse: collapse; } td, th {padding: 10px;} </style><table><tr><th>Username</th><th>Excerpt</th><th>Annotation</th><th>Tag</th><th>Timestamp</th></tr><tr>";
+        jQuery.each(annotations, function(index, annotation) {
+            html += "<td>" + annotation.user.name + "</td>";
+            if (annotation.media === "text") {
+                html += "<td>" + annotation.quote + "</td>";
+            } else if(annotation.media === "image") {
+                html += "<td><img src=\""+annotation.thumb+"\" style=\"max-width: 150px; max-height: 150px;\"/></td>"
+            } else if (annotation.media === "video") {
+                html += "<td>" + annotation.rangeTime.start + " - " + annotation.rangeTime.end + "</td>";
+            }
+            
+            html += "<td>" + annotation.text + "</td><td>";
+            if (annotation.tags && annotation.tags.length > 0) {
+                jQuery.each(annotation.tags, function(tagIndex, tagName) {
+                    html += tagName + "<br>";
+                });
+            };
+            html += "<td>" + annotation.updated + "</td></tr>";
+        });
+        html += "</table>";
+        var wnd = window.open("about:blank", "", "_blank");
+        wnd.document.write(html);
+    };
+
+    $.DashboardView.prototype.exportAnnotations = function() {
+        var annotations = this.initOptions.controller.endpoint.annotationsMasterList;
+        html = "<textarea style='width:600px; height:600px;'>"+ JSON.stringify(annotations, null, 4)+"</textarea>";
+        var wnd = window.open("about:blank", "", "_blank");
+        wnd.document.write(html);
+    };
+
+    $.DashboardView.prototype.importAnnotations = function() {
+        var self = this;
+        var html = this.initOptions.TEMPLATES.importItems();
+        var saved_section_scrolltop = jQuery('.annotationSection').scrollTop();
+        jQuery('.annotationSection').append(html).scrollTop(0);
+        jQuery('.annotationModal #closeModal').click( function (e) {
+            jQuery('.group-wrap').removeClass("hidden");
+            jQuery('.filter-options').removeClass("hidden");
+            jQuery('.search-bar').removeClass("hidden");
+            jQuery('.annotationsHolder').removeClass("hidden");
+            jQuery('.annotationModal').remove();
+            jQuery('.annotationSection').scrollTop(saved_section_scrolltop);
+        });
+
+        jQuery('.annotationModal #importarea').click( function(e) {
+            var content = JSON.parse(jQuery('.annotationModal #importItems').val());
+            var endpoint = self.initOptions.controller.endpoint.endpoint;
+            jQuery.each(content, function(index, value) {
+                value.id = undefined;
+                value.collectionId = endpoint.collection_id;
+                value.contextId = endpoint.context_id;
+
+                endpoint.createCatchAnnotation(value);
+            });
+            jQuery('.annotationModal #closeModal').trigger('click');
+            jQuery('.mirador-osd-refresh-mode').trigger('click');
+        });
     };
 
     $.DashboardView.prototype.updateDashboard = function(offset, pagination_limit, annotationsList, updateStore){
@@ -355,7 +426,16 @@
         jQuery('#loadMoreButton').click(function(){
             loadMore();
         });
-       jQuery('.handle-button').click( function(e) {
+        jQuery('#printAnnotations').click(function(){
+            self.printAnnotations();
+        });
+        jQuery('#exportAnnotations').click(function(){
+            self.exportAnnotations();
+        });
+        jQuery('#importAnnotations').click(function(){
+            self.importAnnotations();
+        });
+        jQuery('.handle-button').click( function(e) {
             if (self.moving) {
                 return;
             };

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -167,12 +167,15 @@
 
         jQuery('.annotationModal #importarea').click( function(e) {
             var content = JSON.parse(jQuery('.annotationModal #importItems').val());
-            var endpoint = self.initOptions.controller.endpoint.endpoint;
+            var endpoint = self.initOptions.endpoint.endpoint;
             jQuery.each(content, function(index, value) {
                 value.id = undefined;
                 value.collectionId = endpoint.collection_id;
                 value.contextId = endpoint.context_id;
-
+                if (value.user.name === endpoint.username) {
+                    value.user.id = endpoint.userid;
+                }
+                
                 endpoint.createCatchAnnotation(value);
             });
             jQuery('.annotationModal #closeModal').trigger('click');

--- a/hx_lti_initializer/static/css/dashboard.css
+++ b/hx_lti_initializer/static/css/dashboard.css
@@ -35,6 +35,46 @@
     cursor:pointer;
     border-bottom: 1px solid #888;
 }
+.annotationSection.side .handleAnnotations #printAnnotations{
+    color: white;
+    font-size: 10pt;
+    float: left;
+    margin-top: 15px;
+    margin-left: 15px;
+    cursor: pointer;
+}
+.annotationSection.side .handleAnnotations #exportAnnotations{
+    color: white;
+    font-size: 10pt;
+    float: right;
+    margin-top: 15px;
+    margin-right: 15px;
+    cursor: pointer;
+}
+
+.annotationSection.side .handleAnnotations #importAnnotations{
+    color: white;
+    font-size: 10pt;
+    float: right;
+    margin-top: 15px;
+    margin-right: 15px;
+    cursor: pointer;
+}
+
+.annotationModal #importItems {
+    margin-top: 70px;
+    margin-left: 5%;
+    margin-right: 5%;
+    width: 90%;
+    height: 150px;
+}
+
+.annotationModal #importarea {
+    margin-top: 10px;
+    margin-left: 5%;
+    margin-right: 5%;
+    width: 90%;
+}
 
 .annotationItem.side:nth-child(even) {
     background-color: #eee;

--- a/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
@@ -40,7 +40,7 @@
             <label for="endTimeFilter">End:</label> <input type="text" id="endTimeFilter" style="display:inline;width:20%; color: black;" value="0:00"/>
         </div>
     </div>
-    <div class="handleAnnotations">
+    <div class="handleAnnotations" style="display:none">
         <div id="printAnnotations"> <i class="fa fa-print"></i>   Print My Notes</div>
         <div id="exportAnnotations"> <i class="fa fa-cloud-download"></i> Export</div>
         <div id="importAnnotations"> <i class="fa fa-cloud-upload"></i> Import</div>

--- a/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
@@ -40,7 +40,11 @@
             <label for="endTimeFilter">End:</label> <input type="text" id="endTimeFilter" style="display:inline;width:20%; color: black;" value="0:00"/>
         </div>
     </div>
-    
+    <div class="handleAnnotations">
+        <div id="printAnnotations"> <i class="fa fa-print"></i>   Print My Notes</div>
+        <div id="exportAnnotations"> <i class="fa fa-cloud-download"></i> Export</div>
+        <div id="importAnnotations"> <i class="fa fa-cloud-upload"></i> Import</div>
+    </div>
     <div class="annotationsHolder side" role="list" aria-label="Annotations" >
 		<% _.each(annotationItems, function(item) { %>
 			<%= item %>

--- a/hx_lti_initializer/static/templates/dashboard/importItems_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/importItems_side.html
@@ -1,0 +1,8 @@
+<div class="annotationModal item-new-annotation side">
+	<div class="modal-navigation">
+		<button class="btn btn-default" id="closeModal" aria-label="Cancel - Go back to annotations"><i class="glyphicon glyphicon-arrow-left"></i></button>
+		<div class="label">Import Annotations</div>
+	</div>
+	<textarea id="importItems"></textarea>
+	<button id="importarea" class="btn btn-primary">Import</button>
+</div>

--- a/hx_lti_initializer/static/vendors/development/summernote.js
+++ b/hx_lti_initializer/static/vendors/development/summernote.js
@@ -2373,13 +2373,13 @@
       styleTags: ['p', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 
       // default fontName
-      defaultFontName: 'Helvetica Neue',
+      defaultFontName: 'Open Sans',
 
       // fontName
       fontNames: [
         'Arial', 'Arial Black', 'Comic Sans MS', 'Courier New',
         'Helvetica Neue', 'Helvetica', 'Impact', 'Lucida Grande',
-        'Tahoma', 'Times New Roman', 'Verdana'
+        'Tahoma', 'Times New Roman', 'Verdana', 'Open Sans'
       ],
       fontNamesIgnoreCheck: [],
 


### PR DESCRIPTION
This PR focuses on a very small request from one of our courses. The instructor would like to be able to export their annotations and import them into a new version of the course (i.e. the same target object, but different course or assignment). 

Three new buttons will appear now under "My Notes" if you are an instructor:
- Print
- Export
- Import

Export will open up a new page with a JSON blob that the instructor can copy.
Import will open up a text area in the sidebar that will accept a JSON blob. It will replace all the information that needs to be replaced (i.e. context_id, collection_id).

@arthurian Let me know if you see any issues. I know there's a bit more I want to do with this:
1. Checks to make sure the blob was copied correctly and contains valid data.
2. Feedback about items being added
3. Way to order items added from the blob
4. Or even just a way to do this via the backend and not involving them actually going back and forth copying and pasting items.
5. Specifying which annotations should and should not be imported/exported.