### PR TITLE
Annotation Modes sans Anonymous

### DIFF
--- a/hx_lti_assignment/forms.py
+++ b/hx_lti_assignment/forms.py
@@ -33,6 +33,9 @@ class AssignmentForm(forms.ModelForm):
                 Tab(
                     'Annotation Table Settings',
                     'include_instructor_tab',
+                    'include_mynotes_tab',
+                    'include_public_tab',
+                    HTML("<p><em>Note:</em> Turning off all three will turn on Zen mode where only the object is shown. Annotations cannot be made.</p>"),
                     Field('default_tab', css_class="selectpicker"),
                     'pagination_limit',
                 ),

--- a/hx_lti_assignment/migrations/0007_auto_20160503_1720.py
+++ b/hx_lti_assignment/migrations/0007_auto_20160503_1720.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hx_lti_assignment', '0006_auto_20151008_1650'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assignment',
+            name='include_mynotes_tab',
+            field=models.BooleanField(default=True, help_text=b"Include a tab for user's annotations. Warning: Turning this off will not allow students to make annotations."),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='assignment',
+            name='include_public_tab',
+            field=models.BooleanField(default=False, help_text=b"Include a tab for public annotations. Used for private annotations. If you want users to view each other's annotations."),
+            preserve_default=True,
+        ),
+    ]

--- a/hx_lti_assignment/migrations/0008_auto_20160503_1721.py
+++ b/hx_lti_assignment/migrations/0008_auto_20160503_1721.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hx_lti_assignment', '0007_auto_20160503_1720'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='assignment',
+            name='include_public_tab',
+            field=models.BooleanField(default=True, help_text=b"Include a tab for public annotations. Used for private annotations. If you want users to view each other's annotations."),
+            preserve_default=True,
+        ),
+    ]

--- a/hx_lti_assignment/models.py
+++ b/hx_lti_assignment/models.py
@@ -136,6 +136,14 @@ class Assignment(models.Model):
         help_text="Include a tab for instructor annotations.",
         default=False
     )
+    include_mynotes_tab = models.BooleanField(
+        help_text="Include a tab for user's annotations. Warning: Turning this off will not allow students to make annotations.",
+        default=True
+    )
+    include_public_tab = models.BooleanField(
+        help_text="Include a tab for public annotations. Used for private annotations. If you want users to view each other's annotations.",
+        default=True
+    )
     allow_highlights = models.BooleanField(
         help_text="Allow predetermined tags with colors.",
         default=False

--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment.html
@@ -35,6 +35,42 @@
 				jQuery('#id_default_tab').find('option').first().removeClass('hidden');
 			} else {
 				jQuery('#id_default_tab').find('option').first().addClass('hidden');
+				if (jQuery('#id_default_tab').val() === "Instructor" ) {
+					var nonHiddenOptions = jQuery('#id_default_tab').find('option:not(.hidden)');
+					if (nonHiddenOptions.length !== 0) {
+						jQuery('#id_default_tab').selectpicker('val', nonHiddenOptions.first().val());
+					}
+				}
+			}
+			
+			jQuery('#id_default_tab').selectpicker('refresh');            
+        });
+        jQuery('#id_include_mynotes_tab').change(function(event){
+			if (jQuery('#id_include_mynotes_tab').is(':checked')) {
+				jQuery(jQuery('#id_default_tab').find('option').get(1)).removeClass('hidden');
+			} else {
+				jQuery(jQuery('#id_default_tab').find('option').get(1)).addClass('hidden');
+				if (jQuery('#id_default_tab').val() === "MyNotes" ) {
+					var nonHiddenOptions = jQuery('#id_default_tab').find('option:not(.hidden)');
+					if (nonHiddenOptions.length !== 0) {
+						jQuery('#id_default_tab').selectpicker('val', nonHiddenOptions.first().val());
+					}
+				}
+			}
+			
+			jQuery('#id_default_tab').selectpicker('refresh');            
+        });
+        jQuery('#id_include_public_tab').change(function(event){
+			if (jQuery('#id_include_public_tab').is(':checked')) {
+				jQuery('#id_default_tab').find('option').last().removeClass('hidden');
+			} else {
+				jQuery('#id_default_tab').find('option').last().addClass('hidden');
+				if (jQuery('#id_default_tab').val() === "Public" ) {
+					var nonHiddenOptions = jQuery('#id_default_tab').find('option:not(.hidden)');
+					if (nonHiddenOptions.length !== 0) {
+						jQuery('#id_default_tab').selectpicker('val', nonHiddenOptions.first().val());
+					}
+				}
 			}
 			
 			jQuery('#id_default_tab').selectpicker('refresh');            

--- a/hx_lti_initializer/static/DashboardController.js
+++ b/hx_lti_initializer/static/DashboardController.js
@@ -82,6 +82,8 @@
 				controller: self,
 				default_tab: self.initOptions.default_tab,
 				show_instructor_tab: self.initOptions.show_instructor_tab,
+				show_mynotes_tab: self.initOptions.show_mynotes_tab,
+				show_public_tab: self.initOptions.show_public_tab,
 				is_instructor: self.initOptions.is_instructor === "True",
 			});
 		});

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -376,6 +376,8 @@
         el.html(self.initOptions.TEMPLATES.annotationSection({
             annotationItems: [],
             show_instructor_tab: self.initOptions.show_instructor_tab,
+            show_mynotes_tab: self.initOptions.show_mynotes_tab,
+            show_public_tab: self.initOptions.show_public_tab
         }));
         console.log(self.initOptions);
         jQuery('.resize-handle').css('right', jQuery('.annotationSection').css('width'));

--- a/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
@@ -9,11 +9,15 @@
         <div class="hide_label" id="sidebar-hide-sidebar-instructions">Click to hide/show sidebar</div>
     <div class="group-wrap">
         <div class="annotation-filter-buttons btn-group">
+            <% if (show_mynotes_tab === "True") {%>
         	<button type="button" class="btn user-filter" id='mynotes' aria-label="View only my annotations" role="button">My Notes</button>
+            <% } %>
             <% if (show_instructor_tab === "True") {%>
             	<button type="button" class="btn user-filter" id='instructor' aria-label="View only instructor annotations" role="button">Instructor</button>
             <% } %>
+            <% if (show_public_tab === "True") {%>
         	<button type="button" class="btn user-filter" id='public' aria-label="View everybody's annotations" role="button">Public</button>
+            <% } %>
         </div>
     </div>
     <div class="separator-solid side"></div>

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -119,6 +119,8 @@
                     instructors: {{ assignment.course.course_admins| list_of_ids | safe}},
                     default_tab: "{{ assignment.default_tab }}",
                     show_instructor_tab: "{{assignment.include_instructor_tab}}",
+                    show_mynotes_tab: "{{assignment.include_mynotes_tab}}",
+                    show_public_tab: "{{assignment.include_public_tab}}",
                     instructions: "{{instructions | escapejs }}",
                     dashboard_hidden: {{dashboard_hidden}},
                     {% if transcript_hidden %}

--- a/hx_lti_initializer/templates/ig/detail.html
+++ b/hx_lti_initializer/templates/ig/detail.html
@@ -81,7 +81,11 @@ var mir = Mirador({
         "canvasID" : "{{ canvas_id }}",
       {% endif %}
       "annotationLayer" : true,
-      "annotationCreation" : true,
+      {% if not assignment.include_mynotes_tab %}
+      "annotationCreation" : false,
+      {% else %}
+      "annotationCreation": true,
+      {% endif %}
   	  "sidePanel" : false,
       "fullScreen" : false,
       "displayLayout": false,

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -117,7 +117,10 @@ Annotation Tool | Text | {{ target_object.target_title }}
       {% if assignment.allow_highlights %}
       'highlightTags_options': "{{ assignment.highlights_options }}",
       {% endif %}
-      'showViewPermissionsCheckbox': {% if org == 'ATG' %}true{% else %}false{% endif %}
+      'showViewPermissionsCheckbox': {% if org == 'ATG' %}true,{% else %}false,{% endif %}
+      {% if not assignment.include_mynotes_tab %}
+      'readOnly': true,
+      {% endif %}
     },
   };
 {% endblock %}

--- a/hx_lti_initializer/templates/vd/detail.html
+++ b/hx_lti_initializer/templates/vd/detail.html
@@ -100,6 +100,9 @@ Annotation Tool | Video | {{ target_object.target_title }}
       {% if assignment.allow_highlights %}
       'highlightTags_options': "{{ assignment.highlights_options }}",
       {% endif %}
+      {% if not assignment.include_mynotes_tab %}
+      'readOnly': true,
+      {% endif %}
     },
   };
 {% endblock %}


### PR DESCRIPTION
@arthurian Can you take a look at this?
Basically instead of having distinct modes, I used the "include X tab" as a way to turn on/off the different use cases. I left anonymous off since that requires some changes to the CATCH if we do want it to be completely anonymous. If we want to do a hack for it where we hide them after they load, we can probably do that. Otherwise, this should add two more options: 1) "Include MyNotes tab" and 2)"Include Public tab" here are the use cases I have in mind:

MyNotes only -> Personal notes without instructor guidance, i.e. reading and taking notes for yourself
Instructor only -> Instructor guidance without allowing them to create their own annotation. This mode should not allow users to make their own annotations. 
Public only -> Not a normal use case, recommend not doing. Buuuut it could happen if for example you want to show annotations from a previous version of the course that include more than instructor ones. This should be read only as well.

MyNotes + Instructor -> Personal notes with instructor guidance. Replies to instructors are still public.
MyNotes + Public -> Open forum without instructor guidance
Instructor + Public -> Same as Public only but with a filter to see just the instructor annotations.

All three -> Read/Write with filter to see your annotations only and instructor annotations only, or everyone.

Take a gander and let me know if you see anything wrong/worrisome.