### PR TITLE
Annotation Database Alert system

### DIFF
--- a/hx_lti_assignment/forms.py
+++ b/hx_lti_assignment/forms.py
@@ -33,6 +33,9 @@ class AssignmentForm(forms.ModelForm):
                 Tab(
                     'Annotation Table Settings',
                     'include_instructor_tab',
+                    'include_mynotes_tab',
+                    'include_public_tab',
+                    HTML("<p><em>Note:</em> Turning off all three will turn on Zen mode where only the object is shown. Annotations cannot be made.</p>"),
                     Field('default_tab', css_class="selectpicker"),
                     'pagination_limit',
                 ),

--- a/hx_lti_assignment/migrations/0007_auto_20160503_1720.py
+++ b/hx_lti_assignment/migrations/0007_auto_20160503_1720.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hx_lti_assignment', '0006_auto_20151008_1650'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assignment',
+            name='include_mynotes_tab',
+            field=models.BooleanField(default=True, help_text=b"Include a tab for user's annotations. Warning: Turning this off will not allow students to make annotations."),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='assignment',
+            name='include_public_tab',
+            field=models.BooleanField(default=False, help_text=b"Include a tab for public annotations. Used for private annotations. If you want users to view each other's annotations."),
+            preserve_default=True,
+        ),
+    ]

--- a/hx_lti_assignment/migrations/0008_auto_20160503_1721.py
+++ b/hx_lti_assignment/migrations/0008_auto_20160503_1721.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hx_lti_assignment', '0007_auto_20160503_1720'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='assignment',
+            name='include_public_tab',
+            field=models.BooleanField(default=True, help_text=b"Include a tab for public annotations. Used for private annotations. If you want users to view each other's annotations."),
+            preserve_default=True,
+        ),
+    ]

--- a/hx_lti_assignment/models.py
+++ b/hx_lti_assignment/models.py
@@ -136,6 +136,14 @@ class Assignment(models.Model):
         help_text="Include a tab for instructor annotations.",
         default=False
     )
+    include_mynotes_tab = models.BooleanField(
+        help_text="Include a tab for user's annotations. Warning: Turning this off will not allow students to make annotations.",
+        default=True
+    )
+    include_public_tab = models.BooleanField(
+        help_text="Include a tab for public annotations. Used for private annotations. If you want users to view each other's annotations.",
+        default=True
+    )
     allow_highlights = models.BooleanField(
         help_text="Allow predetermined tags with colors.",
         default=False

--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment.html
@@ -35,6 +35,42 @@
 				jQuery('#id_default_tab').find('option').first().removeClass('hidden');
 			} else {
 				jQuery('#id_default_tab').find('option').first().addClass('hidden');
+				if (jQuery('#id_default_tab').val() === "Instructor" ) {
+					var nonHiddenOptions = jQuery('#id_default_tab').find('option:not(.hidden)');
+					if (nonHiddenOptions.length !== 0) {
+						jQuery('#id_default_tab').selectpicker('val', nonHiddenOptions.first().val());
+					}
+				}
+			}
+			
+			jQuery('#id_default_tab').selectpicker('refresh');            
+        });
+        jQuery('#id_include_mynotes_tab').change(function(event){
+			if (jQuery('#id_include_mynotes_tab').is(':checked')) {
+				jQuery(jQuery('#id_default_tab').find('option').get(1)).removeClass('hidden');
+			} else {
+				jQuery(jQuery('#id_default_tab').find('option').get(1)).addClass('hidden');
+				if (jQuery('#id_default_tab').val() === "MyNotes" ) {
+					var nonHiddenOptions = jQuery('#id_default_tab').find('option:not(.hidden)');
+					if (nonHiddenOptions.length !== 0) {
+						jQuery('#id_default_tab').selectpicker('val', nonHiddenOptions.first().val());
+					}
+				}
+			}
+			
+			jQuery('#id_default_tab').selectpicker('refresh');            
+        });
+        jQuery('#id_include_public_tab').change(function(event){
+			if (jQuery('#id_include_public_tab').is(':checked')) {
+				jQuery('#id_default_tab').find('option').last().removeClass('hidden');
+			} else {
+				jQuery('#id_default_tab').find('option').last().addClass('hidden');
+				if (jQuery('#id_default_tab').val() === "Public" ) {
+					var nonHiddenOptions = jQuery('#id_default_tab').find('option:not(.hidden)');
+					if (nonHiddenOptions.length !== 0) {
+						jQuery('#id_default_tab').selectpicker('val', nonHiddenOptions.first().val());
+					}
+				}
 			}
 			
 			jQuery('#id_default_tab').selectpicker('refresh');            

--- a/hx_lti_initializer/static/AnnotationCore.js
+++ b/hx_lti_initializer/static/AnnotationCore.js
@@ -195,6 +195,38 @@
 		    
 		    this.annotation_tool.addPlugin(pluginName, options);
 	    } 
+	};
+	$.AnnotationCore.prototype.alert = function(error) {
+		var overlaybckg = document.createElement('div');
+        var overlaydialog = document.createElement('div');
+        jQuery(overlaybckg).css({
+            "background-color": "rgba(33, 33, 33, 0.3)",
+            "width": "100%",
+            "height": "100%",
+            "position": "fixed",
+            "top": "0",
+            "left": "0",
+            "z-index": "999"
+        });
+        jQuery(overlaydialog).css({
+            "background-color": "white",
+            "width": "500px",
+            "height": "420px",
+            "margin-left": "-250px",
+            "margin-top": "-200px",
+            "top": "50%",
+            "left": "50%",
+            "position": "fixed",
+            "z-index": "9999",
+            "border": "4px solid black",
+            "border-radius": "10px",
+        });
+        jQuery(overlaydialog).html("<h3 style='padding-left: 50px; padding-top:10px;'>Uh oh!</h3><p style='padding: 0px 50px;'>Something went wrong with the annotation database. Unfortunately, this means that we are not able to save your annotations or show you the annotations of instructors and other learners. The most common reason is if you were inactive in this page for a while. We recommend refreshing the page or changing browsers.</p> <button role='button' class='btn btn-success' style='margin:5px 50px;width:400px;' id='takemethere' onclick='window.open(\"/troubleshooting/\", \"_blank\");'>Visit troubleshooting page</button><button role='button' class='btn btn-danger' style='margin: 10px 50px;width:400px;' id='ignorewarning'>Proceed without annotations</button> <p style='padding: 10px 50px; text-align:center;'>(Clicking \"Proceed without annotations\" will allow you to view the assignment you are trying to annotate. Unfortunately your annotations will not be saved and you will not see instructor or other leareners' annotations.)</p>");
+        jQuery(overlaybckg).append(overlaydialog);
+        jQuery("body").append(overlaybckg);
+        jQuery('#ignorewarning').click(function(){
+            jQuery(overlaybckg).remove();
+        })
 	}
 
 }(AController));

--- a/hx_lti_initializer/static/DashboardController.js
+++ b/hx_lti_initializer/static/DashboardController.js
@@ -82,6 +82,8 @@
 				controller: self,
 				default_tab: self.initOptions.default_tab,
 				show_instructor_tab: self.initOptions.show_instructor_tab,
+				show_mynotes_tab: self.initOptions.show_mynotes_tab,
+				show_public_tab: self.initOptions.show_public_tab,
 				is_instructor: self.initOptions.is_instructor === "True",
 			});
 		});

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -376,6 +376,8 @@
         el.html(self.initOptions.TEMPLATES.annotationSection({
             annotationItems: [],
             show_instructor_tab: self.initOptions.show_instructor_tab,
+            show_mynotes_tab: self.initOptions.show_mynotes_tab,
+            show_public_tab: self.initOptions.show_public_tab
         }));
         console.log(self.initOptions);
         jQuery('.resize-handle').css('right', jQuery('.annotationSection').css('width'));

--- a/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
@@ -9,11 +9,15 @@
         <div class="hide_label" id="sidebar-hide-sidebar-instructions">Click to hide/show sidebar</div>
     <div class="group-wrap">
         <div class="annotation-filter-buttons btn-group">
+            <% if (show_mynotes_tab === "True") {%>
         	<button type="button" class="btn user-filter" id='mynotes' aria-label="View only my annotations" role="button">My Notes</button>
+            <% } %>
             <% if (show_instructor_tab === "True") {%>
             	<button type="button" class="btn user-filter" id='instructor' aria-label="View only instructor annotations" role="button">Instructor</button>
             <% } %>
+            <% if (show_public_tab === "True") {%>
         	<button type="button" class="btn user-filter" id='public' aria-label="View everybody's annotations" role="button">Public</button>
+            <% } %>
         </div>
     </div>
     <div class="separator-solid side"></div>

--- a/hx_lti_initializer/static/vendors/Annotator/annotator-full.js
+++ b/hx_lti_initializer/static/vendors/Annotator/annotator-full.js
@@ -2415,25 +2415,26 @@
 
     Store.prototype._onError = function(xhr) {
       var action, message;
-      action = xhr._action;
-      message = Annotator._t("Sorry we could not ") + action + Annotator._t(" this annotation");
-      if (xhr._action === 'search') {
-        message = Annotator._t("Sorry we could not search the store for annotations");
-      } else if (xhr._action === 'read' && !xhr._id) {
-        message = Annotator._t("Sorry we could not ") + action + Annotator._t(" the annotations from the store");
-      }
-      switch (xhr.status) {
-        case 401:
-          message = Annotator._t("Sorry you are not allowed to ") + action + Annotator._t(" this annotation");
-          break;
-        case 404:
-          message = Annotator._t("Sorry we could not connect to the annotations store");
-          break;
-        case 500:
-          message = Annotator._t("Sorry something went wrong with the annotation store");
-      }
-      Annotator.showNotification(message, Annotator.Notification.ERROR);
-      return console.error(Annotator._t("API request failed:") + (" '" + xhr.status + "'"));
+      AController.annotationCore.alert(xhr);
+      // action = xhr._action;
+      // message = Annotator._t("Sorry we could not ") + action + Annotator._t(" this annotation");
+      // if (xhr._action === 'search') {
+      //   message = Annotator._t("Sorry we could not search the store for annotations");
+      // } else if (xhr._action === 'read' && !xhr._id) {
+      //   message = Annotator._t("Sorry we could not ") + action + Annotator._t(" the annotations from the store");
+      // }
+      // switch (xhr.status) {
+      //   case 401:
+      //     message = Annotator._t("Sorry you are not allowed to ") + action + Annotator._t(" this annotation");
+      //     break;
+      //   case 404:
+      //     message = Annotator._t("Sorry we could not connect to the annotations store");
+      //     break;
+      //   case 500:
+      //     message = Annotator._t("Sorry something went wrong with the annotation store");
+      // }
+      // Annotator.showNotification(message, Annotator.Notification.ERROR);
+      // return console.error(Annotator._t("API request failed:") + (" '" + xhr.status + "'"));
     };
 
     return Store;

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -119,6 +119,8 @@
                     instructors: {{ assignment.course.course_admins| list_of_ids | safe}},
                     default_tab: "{{ assignment.default_tab }}",
                     show_instructor_tab: "{{assignment.include_instructor_tab}}",
+                    show_mynotes_tab: "{{assignment.include_mynotes_tab}}",
+                    show_public_tab: "{{assignment.include_public_tab}}",
                     instructions: "{{instructions | escapejs }}",
                     dashboard_hidden: {{dashboard_hidden}},
                     {% if transcript_hidden %}

--- a/hx_lti_initializer/templates/ig/detail.html
+++ b/hx_lti_initializer/templates/ig/detail.html
@@ -81,7 +81,11 @@ var mir = Mirador({
         "canvasID" : "{{ canvas_id }}",
       {% endif %}
       "annotationLayer" : true,
-      "annotationCreation" : true,
+      {% if not assignment.include_mynotes_tab %}
+      "annotationCreation" : false,
+      {% else %}
+      "annotationCreation": true,
+      {% endif %}
   	  "sidePanel" : false,
       "fullScreen" : false,
       "displayLayout": false,

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -117,7 +117,10 @@ Annotation Tool | Text | {{ target_object.target_title }}
       {% if assignment.allow_highlights %}
       'highlightTags_options': "{{ assignment.highlights_options }}",
       {% endif %}
-      'showViewPermissionsCheckbox': {% if org == 'ATG' %}true{% else %}false{% endif %}
+      'showViewPermissionsCheckbox': {% if org == 'ATG' %}true,{% else %}false,{% endif %}
+      {% if not assignment.include_mynotes_tab %}
+      'readOnly': true,
+      {% endif %}
     },
   };
 {% endblock %}

--- a/hx_lti_initializer/templates/vd/detail.html
+++ b/hx_lti_initializer/templates/vd/detail.html
@@ -100,6 +100,9 @@ Annotation Tool | Video | {{ target_object.target_title }}
       {% if assignment.allow_highlights %}
       'highlightTags_options': "{{ assignment.highlights_options }}",
       {% endif %}
+      {% if not assignment.include_mynotes_tab %}
+      'readOnly': true,
+      {% endif %}
     },
   };
 {% endblock %}


### PR DESCRIPTION
Really simple, annotator has an error banner drop down for only a few seconds and it's easy to meet if the annotation tool is loaded towards the bottom of the page ("below the fold"). This causes users to create annotations without knowing they won't save (message is also vague and easily ignored). 

This adds a very much "in your face" dialog box with a semi-transparent background that forbids you from interacting with the page until you click the box that says "proceed without making annotations". It also points to the troubleshooting page.