### PR TITLE
Instructions bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 #The HarvardX Annotation Tool (The HxAT)
-LTI tool used by HarvardX to provide annotations to Text and Images to be used in edX courses. 
 
-#Installation
+LTI tool used by HarvardX and HUIT Academic Technology to provide annotations to Text, Images, and Videos on the edX and Canvas platforms. 
+
+# Installation
 
 1. Download the source code
 `git clone https://github.com/lduarte1991/hx-annotations-lti`

--- a/hx_lti_initializer/static/AssignmentEditor.js
+++ b/hx_lti_initializer/static/AssignmentEditor.js
@@ -528,7 +528,7 @@ AssignmentEditor.prototype = {
     reorderList: function() {
         var list = jQuery('.source-item');
         jQuery.each(list, function(index, value) {
-            jQuery(value).data('order', index+1);
+            jQuery(value).attr('data-order', index+1);
             jQuery(value).find('.ordernum').val(index+1);
         });
     },

--- a/hx_lti_initializer/static/AssignmentEditor.js
+++ b/hx_lti_initializer/static/AssignmentEditor.js
@@ -540,7 +540,9 @@ AssignmentEditor.prototype = {
           ("0" + parseInt(rgb[3],10).toString(16)).slice(-2) : '';
     },
     save_form: function() {
-        this.empty_check();
+        if (!this.empty_check()) {
+            return;
+        }
         this.error_check();
 
         jQuery.each(jQuery('.source-item'), function(index, element) {

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -6,6 +6,7 @@
         {% load list_of_ids %}
         {# Load the tag library #}
         {% load bootstrap3 %}
+        {% load hx_lti_initializer_extras %}
 
         {# Load CSS and JavaScript #}
         {% bootstrap_css %}


### PR DESCRIPTION
This PR should fix a bug with editing instructions in the assignment editor.

The form was attempting to pull the instructions text attribute from the Assignment object when it should have been pulling it from the AssignmentTargets object.

Note that I refactored the nested loops so that it just pulls the data from the `AssignmentTargets` model directly, but there might have been a reason to do it the other way, so let me know if you see any issues with that. 