### PR TITLE
Fixes issue with permissiondenied error with a starting resource.

### DIFF
--- a/annotationsx/settings/aws.py
+++ b/annotationsx/settings/aws.py
@@ -114,6 +114,10 @@ LOGGING = {
             'handlers': ['console'],
             'level': SECURE_SETTINGS.get('django_log_level', 'ERROR'),
         },
+        'django.db.backends': {
+            'level': SECURE_SETTINGS.get('django_log_level', 'ERROR'), # DEBUG will show SQL 
+            'handlers': ['console'],
+        },
         'hx_lti_initializer': {
             'handlers': ['console'],
             'level': SECURE_SETTINGS.get('django_log_level', 'ERROR'),

--- a/hx_lti_initializer/admin.py
+++ b/hx_lti_initializer/admin.py
@@ -6,7 +6,7 @@ throughout the LTI. Even courses is only related via the target objects.
 """
 
 from django.contrib import admin
-from hx_lti_initializer.models import LTIProfile, LTICourse
+from hx_lti_initializer.models import LTIProfile, LTICourse, LTIResourceLinkConfig
 
 
 class LTIProfileAdmin(admin.ModelAdmin):
@@ -30,5 +30,10 @@ class LTICourseAdmin(admin.ModelAdmin):
     def course_id(self, instance):  # pragma: no cover
         return str(self.course_id)
 
+class LTIResourceLinkConfigAdmin(admin.ModelAdmin):
+    list_display = ('id', 'collection_id', 'object_id', 'resource_link_id')
+    search_fields = ('collection_id', )
+
 admin.site.register(LTIProfile, LTIProfileAdmin)
 admin.site.register(LTICourse, LTICourseAdmin)
+admin.site.register(LTIResourceLinkConfig, LTIResourceLinkConfigAdmin)

--- a/hx_lti_initializer/templates/hx_lti_initializer/admin_hub.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/admin_hub.html
@@ -11,11 +11,18 @@
         {% if is_instructor %}
             <a class="settingslink" href="{% url 'hx_lti_initializer:edit_course' id=course.pk %}"><i class='fa fa-pencil' style='margin-right:4px'></i>Edit course settings</a>
             <div class='starting-resource'><strong>Starting Resource:</strong>
-            {% if starter_object %}
-                <em>{{starter_object | safe}}</em>
-            {% else %}
-                None (Students will see an error)
-            {% endif %}
+              <span class="starting-resource-object">{% if starter_object %}{{starter_object | safe}}{% endif %}</span>
+              <span class="starting-resource-object-none" style="display:{% if starter_object %}none{% else %}block{% endif %};">
+              {% spaceless %}
+                {% if org == "ATG" %}
+                  (Students will see all published assignments)
+                {% else %}
+                  (Students will see an error)
+                {% endif %}
+              {% endspaceless %}
+            </span>
+              <br>
+              <em style="font-size: 9pt;">Click on the checkbox next to the name of the assignment object you'd like learners to land on.</em>
             </div>
         {% endif %}
 
@@ -106,7 +113,7 @@
             var assignment_pk = $this.prop('id');
             var assignment_title = $this.parents(".assignment-item:first").find(".assignment-title").html();
             var url = "/lti_init/launch_lti/assignment/" + assignment_pk + "/delete/";
-            
+
             var html='<div class="delete-popup-overlay"><div class="delete-popup-background"><h3>Delete this Assignment</h3><p>Are you sure you want to delete the assignment: <em>&quot;'+ assignment_title +'&quot;</em></p><p>Deleting this assignment will remove it from the course, and you will lose access to any annotations and instructions that were created.</p><p><input type="checkbox" id="delete-check"><label for="delete-check">I understand that deleting this assignment cannot be undone.</label></p><form action="'+url+'" method="post">'+"{% csrf_token %}"+'<div id="delete-popup-confirm" class="disabled" type="submit" role="button">Delete assignment</div><div id="delete-popup-cancel">Cancel</div></form></div></div>';
             jQuery('body').append(html);
             jQuery('#delete-check').change(function(){
@@ -133,7 +140,7 @@
             var assignment_id = $this.data('assignment-id');
             var object_id = $this.data('object-id');
             var object_name = $this.data('object-name');
-            
+
             var html='<div class="delete-popup-overlay"><div class="source-material-setup-popup-background"><h3>Source Materials Setup Information</h3><p>These are the parameters for the source object: <em>'+ object_name +'</em></p><p>Make sure to add these values as "custom parameters" when setting up the LTI tool. This means this object will be shown to students when they view the tool. You only need to add the first item they will encounter, after that they can navigate through the rest of the assignment using the toolbar.</p><input class="hx-textfield readonlyfield" readonly value="collection_id='+ assignment_id +'"><input class="hx-textfield readonlyfield" readonly value="object_id='+object_id+'"><div id="delete-popup-cancel">Back to the assignments list</div></form></div></div>';
             jQuery('body').append(html);
             jQuery('#delete-check').change(function(){
@@ -155,22 +162,29 @@
             });
         });
         {% if is_instructor %}
-        jQuery('body').on('click', '.make-starting-resource', function() {
+        jQuery('body').on('click', '.make-starting-resource', function(event) {
             var old = jQuery('.make-starting-resource .fa-check-square');
-            jQuery(this).find('.fa').addClass('fa-check-square').removeClass('fa-square-o');
+            var selection = jQuery(this);
+            var is_checked = selection.find('.fa').hasClass('fa-check-square');
+
+            selection.find('.fa').addClass('fa-check-square').removeClass('fa-square-o');
             old.removeClass('fa-check-square').addClass('fa-square-o');
 
             var url = jQuery(this).data('url');
             var title = jQuery(this).data('title');
+            var method = is_checked ? 'DELETE' : 'POST';
+            var success = function(data) {
+                console.log("starting_resource:", method, title, data);
+                jQuery('.starting-resource-object').html(method == 'DELETE' ? 'None' : title);
+                jQuery('.starting-resource-object-none')[method == 'DELETE' ? 'show' : 'hide']();
+            };
+
             jQuery.ajax({
-                method: 'GET',
+                method: method,
                 url: url,
                 async: true,
-                success: function(data) {
-                    jQuery('.starting-resource').html("<strong>Starting Resource: </strong><em>" + title + "</em>");
-                    console.log(data);
-                },
-            })
+                success: success
+            });
             return false;
         });
         {% endif %}

--- a/hx_lti_initializer/templates/hx_lti_initializer/admin_hub.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/admin_hub.html
@@ -11,8 +11,8 @@
         {% if is_instructor %}
             <a class="settingslink" href="{% url 'hx_lti_initializer:edit_course' id=course.pk %}"><i class='fa fa-pencil' style='margin-right:4px'></i>Edit course settings</a>
             <div class='starting-resource'><strong>Starting Resource:</strong>
-              <span class="starting-resource-object">{% if starter_object %}{{starter_object | safe}}{% endif %}</span>
-              <span class="starting-resource-object-none" style="display:{% if starter_object %}none{% else %}block{% endif %};">
+              <span class="starting-resource-object">{% if starter_object %}{{starter_object | safe}}{%else %}None{% endif %}</span>
+              <span class="starting-resource-object-none" style="display:{% if starter_object %}none{% else %}inline{% endif %};">
               {% spaceless %}
                 {% if org == "ATG" %}
                   (Students will see all published assignments)

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -352,7 +352,7 @@ def course_admin_hub(request):
         to = TargetObject.objects.get(pk=object_id)
         starter_object = to.target_title
     except:
-        starter_object = "None"
+        starter_object = None
         object_id = None
         collection_id = None
 

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -224,6 +224,8 @@ def launch_lti(request):
         else:
             debug_printer("DEBUG - User wants to go directly to annotations for a specific target object using UI")
             return access_annotation_target(request, course_id, assignment_id, object_id)
+    except PermissionDenied as e:
+        raise PermissionDenied(e) # make sure to re-raise this exception since we shouldn't proceed
     except:
         # For the use case where the course head wants to display an assignment object instead
         # of the admin_hub upon launch (i.e. for embedded use), this allows the user

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -11,6 +11,7 @@ from django.template import RequestContext
 
 from django.core.exceptions import PermissionDenied
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 from django.core.urlresolvers import reverse
@@ -351,7 +352,7 @@ def course_admin_hub(request):
         to = TargetObject.objects.get(pk=object_id)
         starter_object = to.target_title
     except:
-        starter_object = "<span style='color:red;'>None (Students will see an error).</span><br><span style='font-size: 9pt;'>Click on the checkbox next to the name of the object you'd like learners to land on.</span>"
+        starter_object = "None"
         object_id = None
         collection_id = None
 
@@ -527,10 +528,10 @@ def instructor_dashboard_student_list_view(request):
     '''
     if not request.session['is_staff']:
         raise PermissionDenied("You must be a staff member to view the dashboard.")
-    
+
     context_id = request.session['hx_context_id']
-    user_id = request.session['hx_user_id']    
-    
+    user_id = request.session['hx_user_id']
+
     # Fetch the annotations and time how long the request takes
     fetch_start_time = time.time()
     course_annotations = fetch_annotations_by_course(context_id, annotation_database.ADMIN_GROUP_ID)
@@ -592,14 +593,14 @@ def annotation_database_search(request):
     '''
     This view is intended to be called by the annotation dashboard when searching
     the CATCH database for annotations.
-    
+
     It's essentially a proxy for annotatorJS requests, with a permission check to
     make sure the user is authorized to search the given course and collection.
-    
+
     Required GET parameters:
      - collectionId: this is the assignment model
      - contextId: this is the course identifier as defined by LTI (the "course context")
-    
+
     The optional GET parameters include those specified by the CATCH database as
     search fields.
     '''
@@ -623,7 +624,7 @@ def annotation_database_search(request):
         'x-annotator-auth-token': request.META['HTTP_X_ANNOTATOR_AUTH_TOKEN'],
         'content-type': 'application/json',
     }
-    
+
     # Override the auth token for ATG when the user is a course administrator,
     # so they can query against private annotations that have granted permission to the admin group.
     if settings.ORGANIZATION == "ATG" and session_is_staff:
@@ -651,7 +652,7 @@ def annotation_database_create(request):
     request_object_id = str(json_body['uri'])
     request_context_id = json_body['contextId']
     request_user_id = json_body['user']['id']
-    
+
     if settings.ORGANIZATION == "ATG":
         annotation_database.update_read_permissions(json_body)
 
@@ -863,6 +864,8 @@ def transfer_annotations(request, instructor_only):
 
 
 @login_required
+@csrf_exempt
+@require_http_methods(["POST", "DELETE"])
 def change_starting_resource(request, assignment_id, object_id):
     data = {'response': 'Success'}
     resource_link_id = request.session['resource_link_id']
@@ -871,12 +874,21 @@ def change_starting_resource(request, assignment_id, object_id):
         'assignment_id': assignment_id,
         'object_id': object_id
     })
-    try:
-        config = LTIResourceLinkConfig.objects.get(resource_link_id=resource_link_id)
-        config.collection_id = assignment_id
-        config.object_id = object_id
-        config.save()
-    except:
-        newConfig = LTIResourceLinkConfig(resource_link_id=resource_link_id, collection_id=assignment_id, object_id=object_id)
-        newConfig.save()
+    debug_printer("change_starting_resource (%s): %s" % (request.method, data))
+
+    if request.method == 'POST':
+        try:
+            config = LTIResourceLinkConfig.objects.get(resource_link_id=resource_link_id)
+            config.collection_id = assignment_id
+            config.object_id = object_id
+            config.save()
+            data['response'] = 'Success: Updated'
+        except:
+            newConfig = LTIResourceLinkConfig(resource_link_id=resource_link_id, collection_id=assignment_id, object_id=object_id)
+            newConfig.save()
+            data['response'] = 'Success: Created'
+    elif request.method == 'DELETE':
+        if LTIResourceLinkConfig.objects.filter(resource_link_id=resource_link_id).exists():
+            LTIResourceLinkConfig.objects.get(resource_link_id=resource_link_id).delete()
+        data['response'] = 'Success: Deleted'
     return HttpResponse(json.dumps(data), content_type='application/json')


### PR DESCRIPTION
@lduarte1991 I just looked at this branch and that's more or less what I had in mind. While I was testing it out, I discovered one unexpected thing with unpublished objects: rather than denying students access to unpublished to the object, it falls back to the admin hub view.  

This PR changes that behavior so that if a `PermissionDenied` exception is raised when accessing an annotation target object, the exception is re-raised instead of defaulting to the admin hub view. 

In addition to that change, I made these tweaks as well:
- Registered the `LTIResourceLinkConfig` model with django admin site.
- Modified the logging configuration so that the django SQL queries could be suppressed while debugging (change `django.db.backends.level` to _ERROR_ rather than _DEBUG_).
- Added the ability to deselect a starting resource. For example, in Canvas we have a number of tools installed in the left-hand navigation and students have access to all annotation assignments. If an instructor mistakenly chooses a starting resource, we want them to be able to undo that. 