### PR TITLE
Cookieless Sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 env
 bin
 lib
+node_modules
 include
 *.DS_Store
 *.pyc

--- a/annotationsx/middleware.py
+++ b/annotationsx/middleware.py
@@ -135,3 +135,22 @@ class SessionMiddleware(object):
                                 secure=settings.SESSION_COOKIE_SECURE or None,
                                 httponly=settings.SESSION_COOKIE_HTTPONLY or None)
         return response
+
+
+class CookielessSessionMiddleware(object):
+    def __init__(self):
+        engine = import_module(settings.SESSION_ENGINE)
+        self.SessionStore = engine.SessionStore
+        print "STarting engine"
+
+    def process_request(self, request):
+        session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, request.GET.get('utm_source'))
+        request.session = self.SessionStore(session_key)
+        if not request.session.exists(request.session.session_key):
+            request.session.create()
+
+        try:
+            if (request.META.get('HTTP_X_FORWARDED_FOR', request.META.get('HTTP_X_REAL_IP', request.META.get('REMOTE_ADDR', '1.2.3.4'))) != request.session['logged_ip']):
+                request.session = None
+        except:
+            pass

--- a/annotationsx/settings/aws.py
+++ b/annotationsx/settings/aws.py
@@ -54,6 +54,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'annotationsx.middleware.XFrameOptionsMiddleware',
     #'annotationsx.middleware.SessionMiddleware',
+    'annotationsx.middleware.CookielessSessionMiddleware',
 )
 
 ROOT_URLCONF = 'annotationsx.urls'

--- a/hx_lti_initializer/static/AnnotationCore.js
+++ b/hx_lti_initializer/static/AnnotationCore.js
@@ -119,11 +119,11 @@
 	                },
 	                urls: {
 	                    // These are the default URLs.
-	                    create:  '/create',
-	                    read:    '/read/:id',
-	                    update:  '/update/:id',
-	                    destroy: '/delete/:id',
-	                    search:  '/search'
+	                    create:  '/create?utm_source=' + this.initOptions.utm_source,
+	                    read:    '/read/:id?utm_source=' + this.initOptions.utm_source,
+	                    update:  '/update/:id?utm_source=' + this.initOptions.utm_source,
+	                    destroy: '/delete/:id?utm_source=' + this.initOptions.utm_source,
+	                    search:  '/search?utm_source=' + this.initOptions.utm_source
 	                },
 	                loadFromSearch:{
 	                    uri: this.initOptions.object_id,
@@ -226,7 +226,7 @@
         jQuery("body").append(overlaybckg);
         jQuery('#ignorewarning').click(function(){
             jQuery(overlaybckg).remove();
-        })
+        });
 	}
 
 }(AController));

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -56,13 +56,13 @@
             {% endif %}
             <div class="pagination">
                 {% if prev_object %}
-                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=prev_object.target_object.id %}" class="btn btn-default" role="button" id="prev_target_object" aria-label="Move to previous document"><i class="glyphicon glyphicon-chevron-left"></i> Previous</a>
+                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=prev_object.target_object.id %}?utm_source={{utm_source}}" class="btn btn-default" role="button" id="prev_target_object" aria-label="Move to previous document"><i class="glyphicon glyphicon-chevron-left"></i> Previous</a>
                 {% endif %}
                 {% if prev_object or next_object %}
                     <div class="pages" aria-label="You are in document {{assignment_target.order}} out of {{assignment.assignment_objects.count}}.">{{assignment_target.order}} / {{ assignment.assignment_objects.count }}</div>
                 {% endif %}
                 {% if next_object %}
-                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=next_object.target_object.id %}" class="btn btn-default" role="button" id="next_target_object" aria-label="Move to next document">Next <i class="glyphicon glyphicon-chevron-right"></i></a><br />
+                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=next_object.target_object.id %}?utm_source={{utm_source}}" class="btn btn-default" role="button" id="next_target_object" aria-label="Move to next document">Next <i class="glyphicon glyphicon-chevron-right"></i></a><br />
                 {% endif %}
             </div>
             
@@ -99,6 +99,7 @@
                 user_id: "{{ user_id }}",
                 is_instructor: "{{ is_instructor }}",
                 pagination: {{ assignment.pagination_limit }},
+                utm_source: "{{ utm_source }}"
             },
 
             // this should handle the colorization of the target

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -192,44 +192,44 @@
         jQuery('.annotation-fullscreen').click(toggleFullscreen);
     </script>
     <script>
-    var receiveMessage = function (evt) {
-      if (evt.data === 'MM:3PCunsupported') {
-        console.log('third party cookies are not supported');
-        var overlaybckg = document.createElement('div');
-        var overlaydialog = document.createElement('div');
-        jQuery(overlaybckg).css({
-            "background-color": "rgba(33, 33, 33, 0.3)",
-            "width": "100%",
-            "height": "100%",
-            "position": "fixed",
-            "top": "0",
-            "left": "0",
-            "z-index": "999"
-        });
-        jQuery(overlaydialog).css({
-            "background-color": "white",
-            "width": "500px",
-            "height": "400px",
-            "margin-left": "-250px",
-            "margin-top": "-200px",
-            "top": "50%",
-            "left": "50%",
-            "position": "fixed",
-            "z-index": "9999",
-            "border": "4px solid black",
-            "border-radius": "10px",
-        });
-        jQuery(overlaydialog).html("<h3 style='padding-left: 50px; padding-top:10px;'>Uh oh!</h3><p style='padding: 0px 50px;'>You seem to have third-party cookies and data turned off. Unfortunately, this means that we are not able to save your annotations or show you the annotations of instructors and other learners, since we will not be able to get information about who you are.</p> <button role='button' class='btn btn-success' style='margin:5px 50px;width:400px;' id='takemethere' onclick='window.open(\"/troubleshooting/\", \"_blank\");'>Visit troubleshooting page</button><button role='button' class='btn btn-danger' style='margin: 10px 50px;width:400px;' id='ignorewarning'>Proceed without annotations</button> <p style='padding: 10px 50px; text-align:center;'>(Clicking \"Proceed without annotations\" will allow you to view the assignment you are trying to annotate. Unfortunately your annotations will not be saved and you will not see instructor or other leareners' annotations.)</p>");
-        jQuery(overlaybckg).append(overlaydialog);
-        jQuery("body").append(overlaybckg);
-        jQuery('#ignorewarning').click(function(){
-            jQuery(overlaybckg).remove();
-        })
-      } else if (evt.data === 'MM:3PCsupported') {
-        console.log('third party cookies are supported');
-      }
-    };
-    window.addEventListener("message", receiveMessage, false);
+    // var receiveMessage = function (evt) {
+    //   if (evt.data === 'MM:3PCunsupported') {
+    //     console.log('third party cookies are not supported');
+    //     var overlaybckg = document.createElement('div');
+    //     var overlaydialog = document.createElement('div');
+    //     jQuery(overlaybckg).css({
+    //         "background-color": "rgba(33, 33, 33, 0.3)",
+    //         "width": "100%",
+    //         "height": "100%",
+    //         "position": "fixed",
+    //         "top": "0",
+    //         "left": "0",
+    //         "z-index": "999"
+    //     });
+    //     jQuery(overlaydialog).css({
+    //         "background-color": "white",
+    //         "width": "500px",
+    //         "height": "400px",
+    //         "margin-left": "-250px",
+    //         "margin-top": "-200px",
+    //         "top": "50%",
+    //         "left": "50%",
+    //         "position": "fixed",
+    //         "z-index": "9999",
+    //         "border": "4px solid black",
+    //         "border-radius": "10px",
+    //     });
+    //     jQuery(overlaydialog).html("<h3 style='padding-left: 50px; padding-top:10px;'>Uh oh!</h3><p style='padding: 0px 50px;'>You seem to have third-party cookies and data turned off. Unfortunately, this means that we are not able to save your annotations or show you the annotations of instructors and other learners, since we will not be able to get information about who you are.</p> <button role='button' class='btn btn-success' style='margin:5px 50px;width:400px;' id='takemethere' onclick='window.open(\"/troubleshooting/\", \"_blank\");'>Visit troubleshooting page</button><button role='button' class='btn btn-danger' style='margin: 10px 50px;width:400px;' id='ignorewarning'>Proceed without annotations</button> <p style='padding: 10px 50px; text-align:center;'>(Clicking \"Proceed without annotations\" will allow you to view the assignment you are trying to annotate. Unfortunately your annotations will not be saved and you will not see instructor or other leareners' annotations.)</p>");
+    //     jQuery(overlaybckg).append(overlaydialog);
+    //     jQuery("body").append(overlaybckg);
+    //     jQuery('#ignorewarning').click(function(){
+    //         jQuery(overlaybckg).remove();
+    //     })
+    //   } else if (evt.data === 'MM:3PCsupported') {
+    //     console.log('third party cookies are supported');
+    //   }
+    // };
+    // window.addEventListener("message", receiveMessage, false);
   </script>
   <iframe src="/static/start.html" style="display:none" />
     {% block endscripts %}{% endblock %}

--- a/hx_lti_initializer/templates/ig/detail.html
+++ b/hx_lti_initializer/templates/ig/detail.html
@@ -113,7 +113,7 @@ var mir = Mirador({
       prefix: "/lti_init/annotation_api",
       userid : "{{ user_id }}",
       username : "{{ username }}",
-      roles : "{{ roles }}",
+      roles : {{ roles |safe }},
       collection_id : "{{ collection }}",
       context_id : "{{ course }}",
     }

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -97,6 +97,8 @@ def launch_lti(request):
     # In canvas this would be the SIS user id, in edX the registered username
     external_user_id = get_lti_value('lis_person_sourcedid', tool_provider)
 
+    request.session['logged_ip'] = request.META.get('HTTP_X_FORWARDED_FOR', request.META.get('HTTP_X_REAL_IP', request.META.get('REMOTE_ADDR', '1.2.3.4')))
+
     # This handles the rare case in which we have neither display name nor external user id
     if not (display_name or external_user_id):
         try:
@@ -369,7 +371,8 @@ def course_admin_hub(request):
             'debug': debug,
             'starter_object': starter_object,
             'starter_object_id': object_id,
-            'starter_collection_id': collection_id
+            'starter_collection_id': collection_id,
+            'utm_source': request.session.session_key,
         }
     )
 
@@ -439,6 +442,7 @@ def access_annotation_target(
         'instructions': assignment_target.target_instructions,
         'abstract_db_url': abstract_db_url,
         'org': settings.ORGANIZATION,
+        'utm_source': request.session.session_key,
     }
     if not assignment.object_before(object_id) is None:
         original['prev_object'] = assignment.object_before(object_id)

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -372,7 +372,7 @@ def course_admin_hub(request):
             'starter_object': starter_object,
             'starter_object_id': object_id,
             'starter_collection_id': collection_id,
-            'utm_source': request.session.session_key,
+            'utm_source': request.session.session_key if not request.session['is_staff'] else '',
         }
     )
 
@@ -438,11 +438,11 @@ def access_annotation_target(
             assignment.annotation_database_secret_token
         ),
         'assignment': assignment,
-        'roles': roles,
+        'roles': [str(role) for role in roles],
         'instructions': assignment_target.target_instructions,
         'abstract_db_url': abstract_db_url,
         'org': settings.ORGANIZATION,
-        'utm_source': request.session.session_key,
+        'utm_source': request.session.session_key if not request.session['is_staff'] else '',
     }
     if not assignment.object_before(object_id) is None:
         original['prev_object'] = assignment.object_before(object_id)


### PR DESCRIPTION
Sets up middleware to catch and create sessions when user has cookies turned off. It also does IP matching to limit the security vulnerabilities.

@arthurian I don't know if this was an issue in with you guys but we had a constant issue within HarvardX that users would not be able to view the tool because their browser would a) not allow third-party cookies or data to be saved or b) Safari settings will only save cookies of sites visited (and since our server is on a different domain than edX we were not on their list). 

So below you should see that the session_key is passed now when they first initialize the tool. It is normally saved in a cookie with the actual session data stored server-side. Then the key is passed in via the url as a parameter. A middleware detects whether the cookie exists. If it doesn't it will look for the session's name in the parameter and creates the session for the page loaded. 

IP matching checks to make sure that their IP address matches the session's last IP address. If it doesn't then it rejects it and sends a 500 Error. 

Thoughts on this? Or anything wrong/stupid that sticks out for you?

I won't merge this yet since there are a couple of small things I want to fix, but wanted to get this up for your eyes asap. 