### PR TITLE
edX Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 env
 bin
 lib
+node_modules
 include
 *.DS_Store
 *.pyc

--- a/annotationsx/middleware.py
+++ b/annotationsx/middleware.py
@@ -135,3 +135,22 @@ class SessionMiddleware(object):
                                 secure=settings.SESSION_COOKIE_SECURE or None,
                                 httponly=settings.SESSION_COOKIE_HTTPONLY or None)
         return response
+
+
+class CookielessSessionMiddleware(object):
+    def __init__(self):
+        engine = import_module(settings.SESSION_ENGINE)
+        self.SessionStore = engine.SessionStore
+        print "STarting engine"
+
+    def process_request(self, request):
+        session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, request.GET.get('sessionId'))
+        request.session = self.SessionStore(session_key)
+        if not request.session.exists(request.session.session_key):
+            request.session.create()
+
+        try:
+            if (request.META.get('HTTP_X_FORWARDED_FOR', request.META.get('HTTP_X_REAL_IP', request.META.get('REMOTE_ADDR', '1.2.3.4'))) != request.session['logged_ip']):
+                request.session = None
+        except:
+            pass

--- a/annotationsx/settings/aws.py
+++ b/annotationsx/settings/aws.py
@@ -53,6 +53,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'annotationsx.middleware.XFrameOptionsMiddleware',
+    'annotationsx.middleware.CookielessSessionMiddleware',
     #'annotationsx.middleware.SessionMiddleware',
 )
 

--- a/hx_lti_initializer/static/AController.js
+++ b/hx_lti_initializer/static/AController.js
@@ -21,4 +21,5 @@ window.AController = window.AController || function(options) {
 		AController.dashboardObjectController = new AController.DashboardController(options.dashboardControllerOptions, options.commonInfo, AController.dashboardView);
 	}
 	AController.main = new AController.AnnotationMain(options);
+	AController.utils = new AController.Utils('https://edge.edx.org');
 }

--- a/hx_lti_initializer/static/AnnotationCore.js
+++ b/hx_lti_initializer/static/AnnotationCore.js
@@ -119,11 +119,11 @@
 	                },
 	                urls: {
 	                    // These are the default URLs.
-	                    create:  '/create',
+	                    create:  '/create?sessionId=' + this.initOptions.session,
 	                    read:    '/read/:id',
 	                    update:  '/update/:id',
 	                    destroy: '/delete/:id',
-	                    search:  '/search'
+	                    search:  '/search?sessionId=' + this.initOptions.session,
 	                },
 	                loadFromSearch:{
 	                    uri: this.initOptions.object_id,

--- a/hx_lti_initializer/static/DashboardController.js
+++ b/hx_lti_initializer/static/DashboardController.js
@@ -98,18 +98,21 @@
 				"user_id": undefined,
 			}, self.initOptions.pagination, self.initOptions.media);
 			self.viewer.removePrintButton();
+			AController.utils.logThatThing('selected_tab', {'tab': 'public'}, 'harvardx', 'hxat');
 		});
 		jQuery('#mynotes').click(function (e){
 			self.endpoint.queryDatabase({
 				"user_id": self.initOptions.user_id,
 			}, self.initOptions.pagination, self.initOptions.media);
 			self.viewer.addPrintButton();
+			AController.utils.logThatThing('selected_tab', {'tab': 'my notes'}, 'harvardx', 'hxat');
 		});
 		jQuery('#instructor').click(function (e){
 			self.endpoint.queryDatabase({
 				"user_id": self.initOptions.instructors,
 			}, self.initOptions.pagination, self.initOptions.media);
 			self.viewer.removePrintButton();
+			AController.utils.logThatThing('selected_tab', {'tab': 'instructor'}, 'harvardx', 'hxat');
 		});
 		
 		jQuery('button#search-submit').click(function (e) {
@@ -119,14 +122,17 @@
 				self.endpoint.queryDatabase({
 					"username": text,
 				}, self.initOptions.pagination, self.initOptions.media);
+				AController.utils.logThatThing('selected_search_filter', {'filter': 'username', 'search_term': text}, 'harvardx', 'hxat');
 			} else if (search_filter === "annotationtext-filter"){
 				self.endpoint.queryDatabase({
 					"text": text,
 				}, self.initOptions.pagination, self.initOptions.media);
+				AController.utils.logThatThing('selected_search_filter', {'filter': 'annotation text', 'search_term': text}, 'harvardx', 'hxat');
 			} else if (search_filter === "tag-filter"){
 				self.endpoint.queryDatabase({
 					"tag": text,
-				}, self.initOptions.pagination, self.initOptions.media)
+				}, self.initOptions.pagination, self.initOptions.media);
+				AController.utils.logThatThing('selected_search_filter', {'filter': 'tag', 'search_term': text}, 'harvardx', 'hxat');
 			}
 		});
 
@@ -155,6 +161,7 @@
 
 		loadFromSearch.limit = this.initOptions.pagination + numberOfAnnotations;
 		annotator.plugins.Store.loadAnnotationsFromSearch(loadFromSearch);
+		AController.utils.logThatThing('load_more_annotations', {}, 'harvardx', 'hxat');
 	};
 
 	$.DashboardController.prototype.annotationsLoaded = function (annotations) {
@@ -164,6 +171,8 @@
 			if (typeof self.initOptions.focus_on_annotation !== "undefined") {
 				self.endpoint.updateMasterList(self.initOptions.focus_on_annotation, self.viewer);
 				self.initOptions.focus_on_annotation = undefined;
+				AController.utils.logThatThing('focused_on_annotation', {}, 'harvardx', 'hxat');
+
 			} else {
 				self.endpoint.updateMasterList();
 				if (self.endpoint.getNumOfAnnotationsOnScreen() > self.initOptions.pagination) {
@@ -171,6 +180,7 @@
 				};
 				self.viewer.clearDashboard();
 				self.viewer.updateDashboard(0, self.initOptions.pagination, annotations, false);
+				AController.utils.logThatThing('loaded_annotations', {}, 'harvardx', 'hxat');
 			}
 		});
 	};
@@ -185,6 +195,8 @@
 					if (typeof annotation.id !== 'undefined') {
 						self.endpoint.addNewAnnotationToMasterList(annotation);
 						self.viewer.addCreatedAnnotation(annotation.media, annotation);
+						AController.utils.logThatThing('annotation_created', {"annotation": annotation}, 'harvardx', 'hxat');
+
 					} else {
 						attempts++;
 						isChanged();
@@ -199,6 +211,8 @@
 		//console.log("AnnotationsUpdated Triggered");
 		this.endpoint.updateAnnotationInMasterList(annotation);
 		this.viewer.updateAnnotation(annotation);
+		AController.utils.logThatThing('annotation_edited', {'annotation': annotation}, 'harvardx', 'hxat');
+
 	};
 
 	$.DashboardController.prototype.annotationDeleted = function(annotation) {
@@ -207,7 +221,8 @@
 		if (!isReply) {
 			this.viewer.deleteAnnotation(annotation);
 		};
-		
+		AController.utils.logThatThing('annotation_delted', {'annotation': annotation}, 'harvardx', 'hxat');
+
 	};
 
 	$.DashboardController.prototype.__bind = function(fn, me) { 
@@ -226,6 +241,7 @@
     	self.viewer.displayModalView(annotationClicked, addCreatedAnnotation);
     	var displayReplies = self.__bind(self.viewer.displayReplies, self.viewer);
     	self.endpoint.loadRepliesForParentAnnotation(annotation_id, displayReplies);
+    	AController.utils.logThatThing('annotation_clicked', {'id': annotation_id}, 'harvardx', 'hxat');
     };
 
     $.DashboardController.prototype.instructionsClicked = function(e) {

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -471,6 +471,7 @@
             var section = jQuery('.annotationSection');
             var handle = jQuery('.resize-handle');
             if (parseInt(section.css('width'), 10) >= 150) {
+                AController.utils.logThatThing('toggled_sidebar', {'opening': false}, 'harvardx', 'hxat');
                 jQuery('#leftCol').attr('class', 'col-xs-11');
                 section.css('min-width', '0px');
                 section.css('width', '0px');
@@ -479,6 +480,7 @@
                 jQuery('.modal-navigation').addClass('hidden'); 
                 jQuery('.editgroup').addClass('hidden');
             } else {
+                AController.utils.logThatThing('toggled_sidebar', {'opening': true}, 'harvardx', 'hxat');
                 jQuery('#leftCol').attr('class', 'col-xs-7');
                 section.css('min-width', '150px');
                 section.css('width', '300px');
@@ -701,17 +703,23 @@
             };
             
             self.initOptions.endpoint.openEditorForReply(options);
-           });
+            AController.utils.logThatThing('trying_to_reply', {}, 'harvardx', 'hxat');
+
+        });
 
         jQuery('.parentAnnotation .quoteText').click( function(e){
             jQuery('html, body').animate({
                 scrollTop: jQuery(annotation.highlights[0]).offset().top },
                 'slow'
             );
+            AController.utils.logThatThing('quote_clicked', {"annotation": annotation}, 'harvardx', 'hxat');
+
         });
 
         jQuery('.parentAnnotation .zoomToImageBounds').click( function(e){
             jQuery.publish('fitBounds.' + self.initOptions.endpoint.window.id, annotationItem.rangePosition)
+            AController.utils.logThatThing('thumbnail_clicked', {'annotation': annotationItem}, 'harvardx', 'hxat');
+
         });
 
         jQuery('.parentAnnotation .playMediaButton ').click ( function(e) {
@@ -738,6 +746,8 @@
             } else {
                 playFunction();
             }
+            AController.utils.logThatThing('video_thumbnail_clicked', {'annotation': annotation}, 'harvardx', 'hxat');
+
         });
 
         jQuery('.parentAnnotation #edit').click(function (e){

--- a/hx_lti_initializer/static/TargetObjectController.js
+++ b/hx_lti_initializer/static/TargetObjectController.js
@@ -495,6 +495,14 @@
                     break;
             }
         });
+
+        jQuery('body').on('click', '.mirador-osd-annotations-layer.hud-control', function() {
+            AController.utils.logThatThing('toggle_annotations_display', {'status': 'shown'}, 'harvardx', 'hxat');
+        });
+
+        jQuery('body').on('click', '.mirador-osd-close.hud-control', function() {
+            AController.utils.logThatThing('toggle_annotations_display', {'status': 'hidden'}, 'harvardx', 'hxat');
+        });
         
         // when keyboard users tab away from the keyboard button it hides the qtip
         jQuery('#keyboard-input-button').on('blur', function(event){
@@ -821,8 +829,41 @@
                     new_percentage = 1.0;
                 }
                 self.vid.annotations.rsd.setPosition(1, new_percentage);
-            });            
+            });
 
+            jQuery('body').on('click', '.vjs-showannotations-annotation.vjs-control', function() {
+                var status = 'hidden';
+                if (jQuery(event.target).hasClass('active')) {
+                    status = 'shown';
+                }
+
+                AController.utils.logThatThing('toggle_annotations_display', {'status': status}, 'harvardx', 'hxat');
+            });
+
+            jQuery('body').on('click', '.vjs-statistics-annotation.vjs-control', function() {
+                var status = 'hidden';
+                if (jQuery(event.target).hasClass('active')) {
+                    status = 'shown';
+                }
+
+                AController.utils.logThatThing('toggle_statistics_display', {'status': status}, 'harvardx', 'hxat');
+            });
+
+            jQuery('body').on('click', '.vjs-selector-arrow', function() {
+
+                AController.utils.logThatThing('filter_arrow_selector', {}, 'harvardx', 'hxat');
+            });
+
+            jQuery('body').on('click', '.vjs-transcript-control.vjs-control', function() {
+                setTimeout(function() {
+                    var status = 'hidden';
+                    if (jQuery('#transcript').is(':visible')) {
+                        status = 'shown';
+                    }
+
+                    AController.utils.logThatThing('toggle_transcript', {'status': status}, 'harvardx', 'hxat');
+                }, 1000);
+            });
         };
 
         $.TargetObjectController.prototype.colorizeAnnotation = function(annotationId, rgbColor) {

--- a/hx_lti_initializer/static/TargetObjectController.js
+++ b/hx_lti_initializer/static/TargetObjectController.js
@@ -855,15 +855,26 @@
             });
 
             jQuery('body').on('click', '.vjs-transcript-control.vjs-control', function() {
-                setTimeout(function() {
-                    var status = 'hidden';
-                    if (jQuery('#transcript').is(':visible')) {
-                        status = 'shown';
-                    }
-
-                    AController.utils.logThatThing('toggle_transcript', {'status': status}, 'harvardx', 'hxat');
-                }, 1000);
+                AController.utils.logThatThing('toggle_transcript', {}, 'harvardx', 'hxat');
             });
+
+            jQuery('body').on('click', '.vjs-download-control.vjs-control', function() {
+                AController.utils.logThatThing('clicked_download_button', {}, 'harvardx', 'hxat');
+            });
+
+            if (typeof(jQuery.subscribe) === 'function') {
+                jQuery.subscribe('speed_change', function(_, speed) {
+                    AController.utils.logThatThing('video_speed_changed', {'speed': JSON.stringify(speed)}, 'harvardx', 'hxat');
+                });
+
+                jQuery.subscribe('video_play_button_clicked', function(_) {
+                    AController.utils.logThatThing('video_play_button_clicked', {}, 'harvardx', 'hxat');
+                });
+
+                jQuery.subscribe('captions_toggled', function(_, captions_label) {
+                    AController.utils.logThatThing('captions_toggled', {'caption': captions_label}, 'harvardx', 'hxat');
+                });
+            }
         };
 
         $.TargetObjectController.prototype.colorizeAnnotation = function(annotationId, rgbColor) {

--- a/hx_lti_initializer/static/TargetObjectController.js
+++ b/hx_lti_initializer/static/TargetObjectController.js
@@ -29,7 +29,7 @@
 
         // Shows annotation toggle label only when hovered
         jQuery('.annotations-status').hover(function() {
-                jQuery('.hover-inst').toggleClass("hidden");
+            jQuery('.hover-inst').toggleClass("hidden");
         });
 
         // Actually toggles whether annotaitons are displayed or not
@@ -210,7 +210,7 @@
         
         // deals with the button that turns on keyboard annotations
         jQuery('#make_annotations_panel button').click(function(){
-            
+            AController.utils.logThatThing('clicked_keyboard_input_button', {'media': 'text'}, 'harvardx', 'hxat');
             // if person is trying to start making an annotation via keyboard
             if (jQuery(this).attr('data-toggled') == "false") {
 
@@ -468,6 +468,7 @@
         // in order to toggle on keyboard input mode. mouseup allows focus to actually move
         // screen reader users to the appropriate div.
         jQuery('#keyboard-input-button').on('mouseup', function (event){
+            AController.utils.logThatThing('clicked_keyboard_input_button', {'media': 'image'}, 'harvardx', 'hxat');
             jQuery('.keyboard-command-area').attr('aria-label', 'Click this button to turn on keyboard input. To use keyboard input, select this area. Then use "W", "A", "S", "D" to move around. "-" to zoom out, "=" to zoom in" and lowercase "m" to make an annotation.');
             jQuery('.openseadragon-canvas').attr('tabindex', '-1');
             
@@ -622,6 +623,7 @@
                 self.vid.controlBar.progressControl.seekBar.stepForward();
             });
             Mousetrap.bind('n', function(e){
+                AController.utils.logThatThing('clicked_keyboard_input_button', {'media': 'video'}, 'harvardx', 'hxat');
                 jQuery('.vjs-new-annotation').trigger('click');
             });
 
@@ -872,6 +874,7 @@
                     jQuery('.annotations-status i').addClass('fa-comments');
                     this.annotationsSaved = store.annotations.slice();
                     window.AController.dashboardObjectController.endpoint._clearAnnotator();
+                    AController.utils.logThatThing('toggle_annotations_display', {'status': 'hidden'}, 'harvardx', 'hxat');
                 } else {
                     jQuery('.annotations-status .hover-inst').html("Hide annotations");
                     jQuery('.annotations-status').attr('aria-label', "Hide annotations");
@@ -882,6 +885,7 @@
                             store.registerAnnotation(annotation);
                     });
                     annotator.publish("externalCallToHighlightTags");
+                    AController.utils.logThatThing('toggle_annotations_display', {'status': 'shown'}, 'harvardx', 'hxat');
                 }
                 jQuery('.annotations-status').toggleClass("on");
             };

--- a/hx_lti_initializer/static/utilities.js
+++ b/hx_lti_initializer/static/utilities.js
@@ -1,0 +1,103 @@
+//utilities.js
+
+/*
+ *  jQuery.ajaxSetup
+ *  Makes sure that the csrf cookie is set properly on all your ajax requests
+ *
+ */
+
+jQuery.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+        if (settings.type == 'POST' || settings.type == 'PUT' || settings.type == 'DELETE') {
+            function getCookie(name) {
+                var cookieValue = null;
+                if (document.cookie && document.cookie != '') {
+                    var cookies = document.cookie.split(';');
+                    for (var i = 0; i < cookies.length; i++) {
+                        var cookie = jQuery.trim(cookies[i]);
+                        // Does this cookie string begin with the name we want?
+                        if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                            cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                            break;
+                        }
+                    }
+                }
+                return cookieValue;
+            }
+            if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {
+                // Only send the token to relative URLs i.e. locally.
+                xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken') || window.csrf_token_backup);
+            }
+        }
+    }
+});
+
+/*
+ *  Utils
+ *  Contains items that might be useful elsewhere. In this case it contains a way to
+ *  listen and create messages between the iFrame and the origin page. It will also
+ *  send items via the logThatThing.
+ *
+ */
+
+(function($) {
+    $.Utils = function(origin) {
+        this.init();
+        this.mainOrigin = origin;
+        this.logSource = undefined;
+        this.logOrigin = undefined;
+        return this;
+    };
+
+    // Makes sure that window listens for the iFrame message
+    $.Utils.prototype.init = function() {
+        window.addEventListener('message', this.receiveMessage.bind(this), false);
+        jQuery.subscribe('logThatThing', this.logViaEvent.bind(this));
+    };
+
+    // the only thing that matters is to retain the source and origin once it has received
+    $.Utils.prototype.receiveMessage = function(event) {
+        if (event.data !== undefined) {
+            if (event.data == "hide thread") {
+                jQuery('.new-thread').remove();
+            }
+        }
+        console.log(event);
+        if (event.origin !== this.mainOrigin) {
+            return;
+        }
+        this.logSource = event.source;
+        this.logOrigin = event.origin;
+        console.log(event);
+    };
+
+    // if we are in an iFrame, it sends the events via postMessage
+    // if we are in edX it calls the Logger function
+    // otherwise it just prints it to the console. 
+    $.Utils.prototype.logThatThing = function(action, thing, source, object) {
+        if (this.logSource && this.logSource.postMessage) {
+            // this checks to see if the current codebase is in an iframe with the logger in the parent
+            this.logSource.postMessage({
+                'event': "log",
+                'event-source': source,
+                'event-object': object,
+                'action': action,
+                'object': JSON.stringify(thing)
+            }, this.logOrigin);
+        } else if(window.Logger !== undefined) {
+            // this checks to see if its in the same page as the logger
+            Logger.log(source + '.' + object + '.' + action, JSON.stringify(thing));
+        } else {
+            // for debug
+            console.log("Could not find logger.");
+            console.log("Here's what I would have logged: " + source + '.' + object + '.' + action);
+            console.log(JSON.stringify(thing));
+        }
+    };
+
+    // calls the logThat thing from the pub/sub rather than through deep diving
+    $.Utils.prototype.logViaEvent = function(_, action, thing, source, object) {
+        this.logThatThing(action, thing, source, object);
+    };
+
+}(AController));

--- a/hx_lti_initializer/static/utilities.js
+++ b/hx_lti_initializer/static/utilities.js
@@ -62,13 +62,11 @@ jQuery.ajaxSetup({
                 jQuery('.new-thread').remove();
             }
         }
-        console.log(event);
         if (event.origin !== this.mainOrigin) {
             return;
         }
         this.logSource = event.source;
         this.logOrigin = event.origin;
-        console.log(event);
     };
 
     // if we are in an iFrame, it sends the events via postMessage

--- a/hx_lti_initializer/static/vendors/development/ba-tiny-pubsub.min.js
+++ b/hx_lti_initializer/static/vendors/development/ba-tiny-pubsub.min.js
@@ -1,0 +1,4 @@
+/*! Tiny Pub/Sub - v0.7.0 - 2013-01-29
+* https://github.com/cowboy/jquery-tiny-pubsub
+* Copyright (c) 2013 "Cowboy" Ben Alman; Licensed MIT */
+(function(n){var u=n({});n.subscribe=function(){u.on.apply(u,arguments)},n.unsubscribe=function(){u.off.apply(u,arguments)},n.publish=function(){u.trigger.apply(u,arguments)}})(jQuery);

--- a/hx_lti_initializer/static/vendors/development/video.dev.js
+++ b/hx_lti_initializer/static/vendors/development/video.dev.js
@@ -4278,6 +4278,9 @@ vjs.PlaybackRateMenuButton.prototype.onClick = function(){
   };
   this.player().playbackRate(newRate);
   this.labelEl_.innerHTML = newRate + 'x';
+  if (typeof(jQuery.publish) === "function") {
+      jQuery.publish('speed_change', [newRate]);
+  }
 };
 
 vjs.PlaybackRateMenuButton.prototype.playbackRateSupported = function(){
@@ -4333,6 +4336,9 @@ vjs.PlaybackRateMenuItem.prototype.onClick = function(){
   vjs.MenuItem.prototype.onClick.call(this);
   this.player().playbackRate(this.rate);
   this.player().controlBar.playbackRateMenuButton.labelEl_.innerHTML = this.rate + "x";
+  if (typeof(jQuery.publish) === "function") {
+      jQuery.publish('speed_change', [this.rate]);
+  }
 };
 
 vjs.PlaybackRateMenuItem.prototype.update = function(){
@@ -4477,6 +4483,9 @@ vjs.PosterImage.prototype.createEl = function(){
 vjs.PosterImage.prototype.onClick = function(){
   // Only accept clicks when controls are enabled
   if (this.player().controls()) {
+    if (typeof(jQuery.publish) === "function") {
+      jQuery.publish('video_play_button_clicked');
+    }
     this.player_.play();
   }
 };
@@ -4540,6 +4549,9 @@ vjs.BigPlayButton.prototype.createEl = function(){
 };
 
 vjs.BigPlayButton.prototype.onClick = function(){
+  if (typeof(jQuery.publish) === "function") {
+      jQuery.publish('video_play_button_clicked');
+    }
   this.player_.play();
 };
 /**
@@ -5656,7 +5668,6 @@ vjs.Player.prototype.showTextTrack = function(id, disableSameKind){
       i = 0,
       j = tracks.length,
       track, showTrack, kind;
-
   // Find Track with same ID
   for (;i<j;i++) {
     track = tracks[i];
@@ -6309,6 +6320,10 @@ vjs.TextTrackMenuItem = vjs.MenuItem.extend({
 vjs.TextTrackMenuItem.prototype.onClick = function(){
   vjs.MenuItem.prototype.onClick.call(this);
   this.player_.showTextTrack(this.track.id_, this.track.kind());
+  if (typeof(jQuery.publish) === "function") {
+      var label = this.track.label();
+      jQuery.publish('captions_toggled', [label]);
+    }
 };
 
 vjs.TextTrackMenuItem.prototype.update = function(){

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -28,6 +28,7 @@
         <script src="{% static "vendors/development/bootstrap-confirmation.js" %}"></script>
         {# library for tokenizing tags #}
         <script src="{% static "vendors/development/jquery.tokeninput.js" %}"></script>
+        <script src="{% static "vendors/development/ba-tiny-pubsub.min.js" %}"></script>
 
         {# files needed to run the HxAT #}
         <script src="{% static "AController.js" %}"></script>
@@ -37,6 +38,7 @@
         <script src="{% static "DashboardController.js" %}"></script>
         <script src="{% static "DashboardView.js" %}"></script>
         <script src="{% static "TargetObjectController.js" %}"></script>
+        <script src="{% static "utilities.js" %}"></script>
 
         {# stylesheet for icons, dashboard and instructions #}
         <link rel="stylesheet" href="{% static "vendors/development/css/font-awesome.css" %}">
@@ -56,13 +58,13 @@
             {% endif %}
             <div class="pagination">
                 {% if prev_object %}
-                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=prev_object.target_object.id %}" class="btn btn-default" role="button" id="prev_target_object" aria-label="Move to previous document"><i class="glyphicon glyphicon-chevron-left"></i> Previous</a>
+                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=prev_object.target_object.id %}" class="btn btn-default" role="button" onclick="AController.utils.logThatThing('clicked_previous_source_button', {}, 'harvardx', 'hxat');" id="prev_target_object" aria-label="Move to previous document"><i class="glyphicon glyphicon-chevron-left"></i> Previous</a>
                 {% endif %}
                 {% if prev_object or next_object %}
                     <div class="pages" aria-label="You are in document {{assignment_target.order}} out of {{assignment.assignment_objects.count}}.">{{assignment_target.order}} / {{ assignment.assignment_objects.count }}</div>
                 {% endif %}
                 {% if next_object %}
-                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=next_object.target_object.id %}" class="btn btn-default" role="button" id="next_target_object" aria-label="Move to next document">Next <i class="glyphicon glyphicon-chevron-right"></i></a><br />
+                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=next_object.target_object.id %}" class="btn btn-default" onclick="AController.utils.logThatThing('clicked_next_source_button', {}, 'harvardx', 'hxat');" role="button" id="next_target_object" aria-label="Move to next document">Next <i class="glyphicon glyphicon-chevron-right"></i></a><br />
                 {% endif %}
             </div>
             
@@ -99,6 +101,7 @@
                 user_id: "{{ user_id }}",
                 is_instructor: "{{ is_instructor }}",
                 pagination: {{ assignment.pagination_limit }},
+                session: "{{session}}"
             },
 
             // this should handle the colorization of the target
@@ -230,7 +233,8 @@
     };
     window.addEventListener("message", receiveMessage, false);
   </script>
-  <iframe src="/static/start.html" style="display:none" />
+
+  <iframe src="/static/start.html" style="display:none;" />
     {% block endscripts %}{% endblock %}
     </body>
 </html>

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -97,6 +97,8 @@ def launch_lti(request):
     # In canvas this would be the SIS user id, in edX the registered username
     external_user_id = get_lti_value('lis_person_sourcedid', tool_provider)
 
+    request.session['logged_ip'] = request.META.get('HTTP_X_FORWARDED_FOR', request.META.get('HTTP_X_REAL_IP', request.META.get('REMOTE_ADDR', '1.2.3.4')))
+
     # This handles the rare case in which we have neither display name nor external user id
     if not (display_name or external_user_id):
         try:
@@ -438,6 +440,7 @@ def access_annotation_target(
         'roles': roles,
         'instructions': assignment_target.target_instructions,
         'abstract_db_url': abstract_db_url,
+        'session': request.session.session_key,
         'org': settings.ORGANIZATION,
     }
     if not assignment.object_before(object_id) is None:
@@ -515,6 +518,7 @@ def instructor_dashboard_view(request):
         'user_annotations': [],
         'fetch_annotations_time': 0,
         'org': settings.ORGANIZATION,
+        'session': request.session.session_key,
         'dashboard_context_js': json.dumps({
             'student_list_view_url': reverse('hx_lti_initializer:instructor_dashboard_student_list_view'),
         })


### PR DESCRIPTION
Due to the tool being LTI (i.e. in an iframe) the normal data-collecting that happens in edX via event logs are stymied. In order to allow the parent window and iframe to talk to each other, I've included the usage of postMessage. This still requires the parent page to include some javascript to be able to receive and do something with the messages.

I'm not sure how this all works out on your end @arthurian. If you're not storing/collecting any of this info I don't think adding this should cause any issues in Canvas since there's nothing to receive the message. Let me know if you have any thoughts on how to either a) abstract this even more to help connect to whatever analytics system you have on Canvas or b) allow either of us to be able to turn it on or off whenever we'd like. 