### PR TITLE
Vagrant Dev Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ reports
 *-annotation-list.json
 *-old.json
 *.srt
+/.vagrant
+!/vagrant/provision.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,51 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Our EC2 instances run ubuntu 14.04 (trusty)
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "virtualbox" do |v|
+    # Seems to be required for Ubuntu
+    # https://www.virtualbox.org/manual/ch03.html#settings-processor
+    v.customize ["modifyvm", :id, "--pae", "on"]
+    # Recommended for Ubuntu
+    v.cpus = 2
+    # This VM comes without swap memory enabled, so we need to bump up
+    # from 512 in order to accomodate installation of lxml
+    v.memory = 1024
+  end
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network :forwarded_port, guest: 80, host: 8080
+  config.vm.network :forwarded_port, guest: 8000, host: 8000, auto_correct: true
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network :private_network, ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  
+  config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provisioning
+  # -------------
+  config.vm.provision :shell, path: "vagrant/provision.sh"
+
+end

--- a/hx_lti_initializer/static/AssignmentEditor.js
+++ b/hx_lti_initializer/static/AssignmentEditor.js
@@ -550,7 +550,7 @@ AssignmentEditor.prototype = {
             var mediaType = jQuery(element).attr('data-media');
             var order = jQuery(element).attr('data-order');
             var source_id = jQuery(element).attr('data-id');
-            var form_id = jQuery('input[value='+aTarget+']').attr('id').replace('-id','-');
+            var form_id = jQuery('input[name$=-id][value='+aTarget+']').attr('id').replace('-id','-');
             
             // saves object chosen
             jQuery('#' + form_id + 'target_object').find('option[value="' + source_id + '"]').attr('selected', true);

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -20,8 +20,8 @@ sudo pip install virtualenv
 sudo pip install urllib3[secure]
 
 # Setup database 
-sudo -u postgres -i psql -d postgres -c "DROP DATABASE IF EXISTS $PROJECT"
-sudo -u postgres -i psql -d postgres -c "DROP USER IF EXISTS $PROJECT"
+#sudo -u postgres -i psql -d postgres -c "DROP DATABASE IF EXISTS $PROJECT"
+#sudo -u postgres -i psql -d postgres -c "DROP USER IF EXISTS $PROJECT"
 sudo -u postgres -i psql -d postgres -c "CREATE USER $PROJECT WITH PASSWORD '$PROJECT'"
 sudo -u postgres -i psql -d postgres -c "CREATE DATABASE $PROJECT WITH OWNER $PROJECT"
 

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+PROJECT=annotationsx
+USER=vagrant
+HOME=/home/vagrant
+
+# Update packages
+sudo apt-get update
+sudo apt-get -y autoremove
+
+# Install system packages
+sudo apt-get -y install build-essential libffi-dev
+sudo apt-get -y install libxslt1-dev libxml2 libxml2-dev
+sudo apt-get -y install openssl libcurl4-openssl-dev
+sudo apt-get -y install git curl wget unzip
+sudo apt-get -y install python-dev python-pip python-setuptools redis-server
+sudo apt-get -y install postgresql postgresql-contrib libpq-dev
+
+# Install system python dependencies (project-specific will be installed in a virtualenv)
+sudo pip install virtualenv
+sudo pip install urllib3[secure]
+
+# Setup database 
+sudo -u postgres -i psql -d postgres -c "DROP DATABASE IF EXISTS $PROJECT"
+sudo -u postgres -i psql -d postgres -c "DROP USER IF EXISTS $PROJECT"
+sudo -u postgres -i psql -d postgres -c "CREATE USER $PROJECT WITH PASSWORD '$PROJECT'"
+sudo -u postgres -i psql -d postgres -c "CREATE DATABASE $PROJECT WITH OWNER $PROJECT"
+
+sudo -u $USER -s bash
+
+# Ensure github.com ssh public key is in $HOME/.ssh/known_hosts file
+chmod 700 $HOME/.ssh
+if ! grep -sq github.com $HOME/.ssh/known_hosts; then
+	ssh-keyscan github.com >> $HOME/.ssh/known_hosts
+fi
+chmod 744 $HOME/.ssh/known_hosts
+
+# Create symlink from home dir to /vagrant as a convenience 
+if [ ! -h $HOME/$PROJECT ]; then
+	ln -sv /vagrant $HOME/$PROJECT
+fi
+
+# Create virtualenv
+mkdir -pv $HOME/python_environments
+virtualenv $HOME/python_environments/$PROJECT
+. $HOME/python_environments/$PROJECT/bin/activate
+pip install -r $HOME/$PROJECT/requirements.txt 
+
+# Setup $HOME/.bash_profile to automatically source the environment settings 
+echo "export DJANGO_SETTINGS_MODULE=$PROJECT.settings.aws" > $HOME/.env
+echo ". $HOME/python_environments/$PROJECT/bin/activate" >> $HOME/.env
+if ! grep -sq ". $HOME/.env" $HOME/.bash_profile; then
+	echo ". $HOME/.env" >> $HOME/.bash_profile
+fi


### PR DESCRIPTION
@lduarte1991 This PR adds a [vagrant](https://www.vagrantup.com/) configuration file for provisioning a [virtualbox](https://www.virtualbox.org/wiki/VirtualBox) server on your local machine. I'm using this as my dev environment (Ubuntu 14.04) instead of running the annotation tool directly on my Mac OS X laptop as in the past.

One of the motivations for the PR was to align my dev environment across machines and also make it easy for other developers to get up and running quickly, since all required packages are installed as part of the provisioning process (see `vagrant/provision.sh`).

Theoretically, getting up and running is as easy as:

```
$ vagrant up
$ vagrant ssh
$ cd annotationsx
$ nano annotationsx/settings/secure.py # save secure settings file
$ ./manage.py migrate
$ ./manage.py runserver 0.0.0.0:8000
```

The git repository is shared with the virtual server (mounted to `/vagrant`), so files can be edited locally as usual. You only need to SSH into the machine to start the django server. Vagrant is already configured to forward port 8000 from the host machine to the guest machine (see `Vagrantfile`).

One improvement I'd like to make to this is to incorporate the CATCH database so that both the annotation tool and CATCH are running inside the same machine, making it easier to test them both together in a sandboxed environment.

Let me know what you think or if you have any suggestions to the provisioning process.