### PR TITLE
Fixed issues caused when you changed from wired to wireless connection

### DIFF
--- a/annotationsx/middleware.py
+++ b/annotationsx/middleware.py
@@ -153,6 +153,6 @@ class CookielessSessionMiddleware(object):
 
         try:
             if (request.META.get('HTTP_X_FORWARDED_FOR', request.META.get('HTTP_X_REAL_IP', request.META.get('REMOTE_ADDR', '1.2.3.4'))) != request.session['logged_ip']):
-                request.session = None
+                request.session.flush()
         except:
             pass


### PR DESCRIPTION
So, I used the wrong call here originally and it caused issues with the IP matching when switching from a wired to wireless connection and back. I had to clear my cookies for things to work again. This should flush the session so that if you try to infiltrate someone's session given the obfuscated key but the IP doesn't match you don't get any of the data stored in sessions. The real user can just refresh the page (i.e. relaunch LTI tool) for things to work as intended again.