### PR TITLE
added way to validate on a per-course level

### DIFF
--- a/annotationsx/settings/aws.py
+++ b/annotationsx/settings/aws.py
@@ -168,7 +168,8 @@ LTI_SETUP = {
 }
 
 CONSUMER_KEY = SECURE_SETTINGS['CONSUMER_KEY']
-LTI_SECRET = SECURE_SETTINGS['LTI_SECRET'] # ignored if using django_auth_lti
+LTI_SECRET = SECURE_SETTINGS['LTI_SECRET']  # ignored if using django_auth_lti
+LTI_SECRET_DICT = SECURE_SETTINGS['LTI_SECRET_DICT']
 
 ANNOTATION_MANUAL_URL = SECURE_SETTINGS.get("annotation_manual_url", None)
 ANNOTATION_MANUAL_TARGET = SECURE_SETTINGS.get("annotation_manual_target", None)

--- a/hx_lti_initializer/utils.py
+++ b/hx_lti_initializer/utils.py
@@ -59,7 +59,10 @@ def initialize_lti_tool_provider(req):
     Starts the provider given the consumer_key and secret.
     """
     consumer_key = settings.CONSUMER_KEY
-    secret = settings.LTI_SECRET
+    try:
+        secret = settings.LTI_SECRET_DICT[req.POST.get('context_id')]
+    except:
+        secret = settings.LTI_SECRET
 
     # use the function from ims_lti_py app to verify and initialize tool
     provider = DjangoToolProvider(consumer_key, secret, req.POST)


### PR DESCRIPTION
To allow a course-by-course level validation for who can use the tool, I've added a way to add a dictionary to the secure.py file where the key is the "lti_context_id" and the value is a hash string created externally.

For backward compatibility the original secret can stay as a sort of "master key" but should be phased out as soon as possible.