### PR TITLE
Accessibility Fixes

### DIFF
--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
@@ -21,7 +21,7 @@ $(document).ready(function() {
 });
 </script>
 <div class='main-page'>
-	<h2>Assignment Editor</h2>
+	<h3>Assignment Editor</h3>
 
 	<label for='assignment-name-input' class='subheading'>Assignment name:</label>
 	<input class='hx-textfield' type='text' id='assignment-name-input' placeholder="Untitled" value='{{form.instance.assignment_name}}' data-course-id="{{course_id}}">
@@ -34,7 +34,7 @@ $(document).ready(function() {
 		{% else %}
 			<div class='save' id='reorder-list-button'>Reorder list</div>
 			{% for source in targets_form %}
-				<div class='source-item' id='item-{{forloop.counter0}}' data-order='{{source.instance.order}}' data-id='{{source.instance.target_object.pk}}' data-aTarget="{{source.instance.id}}" data-media="{{source.instance.target_type}}">
+				<div class='source-item' id='item-{{forloop.counter0}}' tabindex="0" data-order='{{source.instance.order}}' data-id='{{source.instance.target_object.pk}}' data-aTarget="{{source.instance.id}}" data-media="{{source.instance.target_type}}">
 					<div class='first-row'>
 						<i class='fa fa-caret-right fa-lg' style='color:rgb(55, 124, 182);'></i> <span class='source-title'>{{source.instance.target_object.target_title}}</span>
 						<div class='order-div'><input type="number" class='ordernum' style='display:none;' min="1" value="{{source.instance.order}}"><a href='#' style='display: none' class='order-change-button'>Move</a></div>

--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
@@ -34,10 +34,10 @@ $(document).ready(function() {
 		{% else %}
 			<div class='save' id='reorder-list-button'>Reorder list</div>
 			{% for source in targets_form %}
-				<div class='order-div'><label for="order-div-{{source.instance.order}}" style="display:none;">Order input</label><input type="number" id="order-div-{{source.instance.order}}" class='ordernum' style='display:none;' min="1" value="{{source.instance.order}}"><a href='#' style='display: none' class='order-change-button'>Move</a></div>
+				<div class='source-item' id='item-{{forloop.counter0}}' tabindex="0" data-order='{{source.instance.order}}' data-id='{{source.instance.target_object.pk}}' data-aTarget="{{source.instance.id}}" data-media="{{source.instance.target_type}}">
 					<div class='first-row'>
 						<i class='fa fa-caret-right fa-lg' style='color:rgb(55, 124, 182);'></i> <span class='source-title'>{{source.instance.target_object.target_title}}</span>
-						<div class='order-div'><input type="number" class='ordernum' style='display:none;' min="1" value="{{source.instance.order}}"><a href='#' style='display: none' class='order-change-button'>Move</a></div>
+						<div class='order-div'><label for="order-div-{{source.instance.order}}" style="display:none;">Order input</label><input type="number" id="order-div-{{source.instance.order}}" class='ordernum' style='display:none;' min="1" value="{{source.instance.order}}"><a href='#' style='display: none' class='order-change-button'>Move</a></div>
 					</div>
 					<div class='source-detail' style='display:none'>
 						<div class='detail-metadata'>
@@ -243,8 +243,8 @@ $(document).ready(function() {
 	<input class='hx-textfield full-width readonlyfield' readonly type='text' id='database-url' value='{{form.annotation_database_url.value}}'>
 	<label class='subheading' for='database-api-key'>Annotation database API key</label>
 	<input class='hx-textfield full-width readonlyfield' readonly type='text' id='database-api-key' value='{{form.annotation_database_apikey.value}}'>
-	<label class='subheading' for='database-url'>Annotation database secret token</label>
-	<input class='hx-textfield full-width readonlyfield' readonly type='text' id='database-url' value='{{form.annotation_database_secret_token.value}}'>
+	<label class='subheading' for='database-secret-token'>Annotation database secret token</label>
+	< <input class='hx-textfield full-width readonlyfield' readonly type='text' id='database-secret-token' value='{{form.annotation_database_secret_token.value}}'>
 	<div class='button-collection'>
 		<div class="save" id='database-settings-cancel-button' role='button'>
 			Back to assignment

--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
@@ -34,7 +34,7 @@ $(document).ready(function() {
 		{% else %}
 			<div class='save' id='reorder-list-button'>Reorder list</div>
 			{% for source in targets_form %}
-				<div class='source-item' id='item-{{forloop.counter0}}' tabindex="0" data-order='{{source.instance.order}}' data-id='{{source.instance.target_object.pk}}' data-aTarget="{{source.instance.id}}" data-media="{{source.instance.target_type}}">
+				<div class='order-div'><label for="order-div-{{source.instance.order}}" style="display:none;">Order input</label><input type="number" id="order-div-{{source.instance.order}}" class='ordernum' style='display:none;' min="1" value="{{source.instance.order}}"><a href='#' style='display: none' class='order-change-button'>Move</a></div>
 					<div class='first-row'>
 						<i class='fa fa-caret-right fa-lg' style='color:rgb(55, 124, 182);'></i> <span class='source-title'>{{source.instance.target_object.target_title}}</span>
 						<div class='order-div'><input type="number" class='ordernum' style='display:none;' min="1" value="{{source.instance.order}}"><a href='#' style='display: none' class='order-change-button'>Move</a></div>
@@ -124,7 +124,7 @@ $(document).ready(function() {
 	</div>
 
 	<div class='button-collection'>
-		<div type="submit" class="save" id='save-button' role="button" onclick='window.assignment_editor.save_form();'>
+		<div type="submit" class="save" id='save-button' tabindex="0" role="button" onclick='window.assignment_editor.save_form();'>
 			Save
 		</div>
 		<div class="save" id='cancel-button' role='button' onclick='window.location="{% url 'hx_lti_initializer:course_admin_hub' %}?resource_link_id={{ resource_link_id }}";'>
@@ -179,7 +179,8 @@ $(document).ready(function() {
 		
 		{% for tagname, color in tag_list %}
 		<div class='trow'>
-			<input type='text' value='{{tagname}}' class='custom-tag-name'>
+			<label style='display:none' for="tag-{{tagname}}">Tag name</label>
+		    <input type='text' value='{{tagname}}' id="tag-{{tagname}}" class='custom-tag-name'>
 			<div class='color-selection'>
 				<div class='custom-tag-color-chosen' role='button' style='background-color:{{color}};'></div>
 				<div class='custom-tag-color-menu open'>
@@ -223,10 +224,10 @@ $(document).ready(function() {
 		{% endfor %}
 	</div>
 	<div class='button-collection'>
-		<div type="submit" class="save" id='annotation-settings-save-button' role="button" onclick="window.assignment_editor.save_annotation_settings();">
+		<div type="submit" class="save" id='annotation-settings-save-button' tabindex="0" role="button" onclick="window.assignment_editor.save_annotation_settings();">
 			Save
 		</div>
-		<div class="save" id='annotation-settings-cancel-button' role='button'>
+		<div class="save" id='annotation-settings-cancel-button' tabindex="0" role='button'>
 			Cancel
 		</div>
 	</div>

--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
@@ -180,7 +180,7 @@ $(document).ready(function() {
 		{% for tagname, color in tag_list %}
 		<div class='trow'>
 			<label style='display:none' for="tag-{{tagname}}">Tag name</label>
-		    <input type='text' value='{{tagname}}' id="tag-{{tagname}}" class='custom-tag-name'>
+			<input type='text' value='{{tagname}}' id="tag-{{tagname}}" class='custom-tag-name'>
 			<div class='color-selection'>
 				<div class='custom-tag-color-chosen' role='button' style='background-color:{{color}};'></div>
 				<div class='custom-tag-color-menu open'>
@@ -244,9 +244,9 @@ $(document).ready(function() {
 	<label class='subheading' for='database-api-key'>Annotation database API key</label>
 	<input class='hx-textfield full-width readonlyfield' readonly type='text' id='database-api-key' value='{{form.annotation_database_apikey.value}}'>
 	<label class='subheading' for='database-secret-token'>Annotation database secret token</label>
-	< <input class='hx-textfield full-width readonlyfield' readonly type='text' id='database-secret-token' value='{{form.annotation_database_secret_token.value}}'>
+	<input class='hx-textfield full-width readonlyfield' readonly type='text' id='database-secret-token' value='{{form.annotation_database_secret_token.value}}'>
 	<div class='button-collection'>
-		<div class="save" id='database-settings-cancel-button' role='button'>
+		<div class="save" id='database-settings-cancel-button' role='button' tabindex="0">
 			Back to assignment
 		</div>
 	</div>
@@ -262,7 +262,8 @@ $(document).ready(function() {
 	{% if forloop.counter0 < number_of_targets %}
 	<tr id="row{{forloop.counter}}" class="ui-state-default assignment-targets-table-row">
 						<td class="field-target_object" >
-							<select id="id_assignmenttargets_set-{{forloop.counter0}}-target_object" name="assignmenttargets_set-{{forloop.counter0}}-target_object" class="selectpicker form-control" data-live-search="true">
+							<label for="id_assignmenttargets_set-{{forloop.counter0}}-target_object">Sources</label>
+                               <select id="id_assignmenttargets_set-{{forloop.counter0}}-target_object" name="assignmenttargets_set-{{forloop.counter0}}-target_object" class="selectpicker form-control">
 								{% for id,choice in form.fields.assignment_objects.choices %}
 								<option value="{{ id }}" {% if id|slugify == item.target_object.value|slugify %} selected {% endif %}>{{ choice }}</option>
 								{% endfor %}
@@ -298,17 +299,21 @@ $(document).ready(function() {
 								 	{% endif %} 
 								 {% endif %}
 								{% endfor %}
+								<label for="id_assignmenttargets_set-{{forloop.counter0}}-target_external_options" style="display:none;">External Options (advanced user only)</label>
 								<textarea id="id_assignmenttargets_set-{{forloop.counter0}}-target_external_options" name="assignmenttargets_set-{{forloop.counter0}}-target_external_options" class="form-control">{{ item.target_external_options.value }}</textarea>
 							</div>
 						</td>
 						<td>
-							<a href="{% url "target_object_database:popUpNewSource" %}?resource_link_id={{ resource_link_id }}" class="add-another" id="add_id_assignmenttargets_set-{{forloop.counter0}}-target_object" onclick="return showAddAnotherPopup(this);" title="Create New Source Material">{% bootstrap_icon "plus" %}</a>
+							 <a href="{% url "target_object_database:popUpNewSource" %}" class="add-another" id="add_id_assignmenttargets_set-{{forloop.counter0}}-target_object" onclick="return showAddAnotherPopup(this);" title="Create New Source Material">{% bootstrap_icon "plus" %} Create New</a>
 						</td>
-						<td class="field-order hidden"><input id="id_assignmenttargets_set-{{forloop.counter0}}-order" name="assignmenttargets_set-{{forloop.counter0}}-order" value='{{item.order.value}}'></td>
+						<td class="field-order hidden">
+							<label for="id_assignmenttargets_set-{{forloop.counter0}}-order" style="display: none;">Order (advanced use only)</label>
+							<input id="id_assignmenttargets_set-{{forloop.counter0}}-order" name="assignmenttargets_set-{{forloop.counter0}}-order" value='{{item.order.value}}'></td>
 						<td class="field-settings clickable" data-toggle="collapse" data-target="#assignment-target-object-settings-{{forloop.counter0}}" role="button">{% bootstrap_icon "cog" %}</td>
-						<td class="field-delete"><a href='#' onclick="deleterow(this)" title="Remove Source Material from Assignment">{% bootstrap_icon "trash" %}</a>{% if item.instance.pk and targets_form.can_delete%} <input class="hidden" data-id="{{item.target_object.value}}" id="id_assignmenttargets_set-{{forloop.counter0}}-DELETE" name="assignmenttargets_set-{{forloop.counter0}}-DELETE" type="checkbox" />{% endif %}</td>
+						<td class="field-delete"><a href='#' onclick="deleterow(this)" title="Remove Source Material from Assignment">{% bootstrap_icon "trash" %} Delete</a>{% if item.instance.pk and targets_form.can_delete%}<label for="id_assignmenttargets_set-{{forloop.counter0}}-DELETE" style="display:none;">Delete item (advanced use only)</label> <input class="hidden" data-id="{{item.target_object.value}}" id="id_assignmenttargets_set-{{forloop.counter0}}-DELETE" name="assignmenttargets_set-{{forloop.counter0}}-DELETE" type="checkbox" />{% endif %}</td>
 						<td class="field-reorder">{% bootstrap_icon "option-vertical" %}
 						{% if item.id.value %}
+						<label for="id_assignmenttargets_set-{{forloop.counter0}}-id" style="dislpay:none;">Value (advanced use only)</label>
 						<input class="hidden" id="id_assignmenttargets_set-{{forloop.counter0}}-id" name="assignmenttargets_set-{{forloop.counter0}}-id" value='{{item.id.value}}'>
 						{% endif %}
 						</td>

--- a/hx_lti_initializer/static/AController.js
+++ b/hx_lti_initializer/static/AController.js
@@ -9,6 +9,9 @@
  */
 
 window.AController = window.AController || function(options) {
+	Acontroller.accessibility = new AController.Accessibility({
+		'triggerClicks': ['.clicking_allowed']
+	});
 	if (typeof options.targetObjectOptions !== "undefined") {
 		AController.targetObjectController = new AController.TargetObjectController(options.targetObjectOptions, options.commonInfo);
 	}
@@ -23,4 +26,4 @@ window.AController = window.AController || function(options) {
 	AController.main = new AController.AnnotationMain(options);
 	var logger_url = options.commonInfo.logger_url || "";
 	AController.utils = new AController.Utils(logger_url);
-}
+};

--- a/hx_lti_initializer/static/AController.js
+++ b/hx_lti_initializer/static/AController.js
@@ -9,7 +9,7 @@
  */
 
 window.AController = window.AController || function(options) {
-	Acontroller.accessibility = new AController.Accessibility({
+	AController.accessibility = new AController.Accessibility({
 		'triggerClicks': ['.clicking_allowed']
 	});
 	if (typeof options.targetObjectOptions !== "undefined") {

--- a/hx_lti_initializer/static/AnnotationStoreController.js
+++ b/hx_lti_initializer/static/AnnotationStoreController.js
@@ -676,7 +676,7 @@ MiradorEndpointController.prototype.editAnnotation = function(annotation, button
 		if (jQuery('.parentAnnotation .body').summernote !== undefined) {
 			jQuery('.parentAnnotation .body').destroy();
 		} else if(tinymce !== undefined){
-			tinymce.remote();
+			tinymce.remove();
 		}
 	};
 

--- a/hx_lti_initializer/static/AssignmentEditor.js
+++ b/hx_lti_initializer/static/AssignmentEditor.js
@@ -93,7 +93,7 @@ AssignmentEditor.prototype = {
     set_up_source_expanding: function() {
         var self = this;
         // toggles source tailed view from clicking on the row with the name
-        this.source_list.on('click', '.source-item .first-row', function(event) {
+        var expand_from_first_row = function(event) {
             event.preventDefault ? event.preventDefault() : (event.returnValue = false);
             var source_item = jQuery(this.parentElement);
             var source_item_arrow = source_item.find('.fa-lg');
@@ -110,6 +110,12 @@ AssignmentEditor.prototype = {
                 to_list.show();
                 source_item.addClass('open');
             }
+        };
+
+        this.source_list.on('click', '.source-item .first-row', expand_from_first_row);
+        this.keyPressOn('.source-materials', '.source-item .first-row', {
+            'SPACE': expand_from_first_row,
+            'ENTER': expand_from_first_row
         });
 
         // toggles the advanced settings of each source
@@ -143,7 +149,7 @@ AssignmentEditor.prototype = {
                 "popup_title": 'Delete this assignment',
                 "popup_content": '<p>Are you sure you want to remove the annotation source: <em>&quot;'+ object_title +'&quot;</em> from the assignment: <em>&quot;' + assignment_title + '&quot</em></p><p>This action will only remove the source object from this individual assignment, and will not affect any other assignments or courses where it is used.</p>',
                 "popup_confirm": '<div id="delete-popup-confirm" type="submit" role="button">Remove source</div>',
-            }
+            };
             
             jQuery('body').append(self.TEMPLATES['popup_window'](context));
 
@@ -654,7 +660,35 @@ AssignmentEditor.prototype = {
     error_check: function(){
         console.log('Checking to see if there are any errors in the form');  
     },
-    
+
+    keyPressOn: function(parent, child, codesAndFuncs) {
+        var self = this;
+        jQuery(parent).on('keypress', child, function(event) {
+            var key = event.keyCode ? event.keyCode : event.which;
+            jQuery.each(codesAndFuncs, function(keyCode, value) {
+                if (key == self.keyCodeValue(keyCode)) {
+                    value();
+                }
+            });
+            return false;
+        });
+    },
+
+    keyCodeValue: function(keyCode) {
+        switch(keyCode.toUpperCase()) {
+            case 'SPACE':
+            case 'SPACEBAR':
+            case 'SPACE BAR':
+                return 32;
+                break;
+            case 'ENTER':
+            case 'ENT':
+                return 13;
+                break;
+            default:
+                return parseInt(keyCode, 10);
+        }
+    }
 };
 
 jQuery(document).ready(function() {

--- a/hx_lti_initializer/static/DashboardController.js
+++ b/hx_lti_initializer/static/DashboardController.js
@@ -118,6 +118,7 @@
 		jQuery('button#search-submit').click(function (e) {
 			var text = jQuery('#srch-term').val();
 			var search_filter = self.viewer.getSelectedFilterValue().attr("id");
+			jQuery('#hxat-alert').html('Search has been completed. Traverse filtered list below.');
 			if (search_filter === "users-filter"){
 				self.endpoint.queryDatabase({
 					"username": text,
@@ -139,6 +140,7 @@
 		jQuery('button#search-clear').click(function (e) {
 			jQuery('#srch-term').val("");
 			self.viewer.getSelectedTabValue().trigger("click");
+			jQuery('#hxat-alert').html('Search has been cleared. List below shows all annotations.');
 		});
 
 		var annotationClicked = self.__bind(self.annotationClicked, self);

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -165,6 +165,7 @@
             jQuery('.annotationsHolder').removeClass("hidden");
             jQuery('.annotationModal').remove();
             jQuery('.annotationSection').scrollTop(saved_section_scrolltop);
+            jQuery('.annotationSection').focus();
         });
 
         jQuery('.annotationModal #importarea').click( function(e) {
@@ -716,6 +717,7 @@
             jQuery('.annotationsHolder').removeClass("hidden");
             jQuery('.annotationModal').remove();
             jQuery('.annotationSection').scrollTop(saved_section_scrolltop);
+            jQuery('.item-' + annotationItem.id + ' .totalreplies').focus();
         });
         jQuery('.annotationModal #hideParent').click( function (e) {
             jQuery('.parentAnnotation').toggleClass("hidden");
@@ -800,7 +802,10 @@
         jQuery('.annotationModal svg').show();
         if (annotationItem.tags && annotationItem.tags.length > 0) {
             var tagColor = this.getAnnotationColor(annotationItem);
-            var cssColor = "rgba(" + tagColor.red + ", " + tagColor.green + ", " + tagColor.blue + ", 1)";
+            var cssColor = "";
+            if (typeof tagColor !== "undefined") {
+                cssColor = "rgba(" + tagColor.red + ", " + tagColor.green + ", " + tagColor.blue + ", 1)";
+            }
             jQuery('.annotationModal svg path').attr('stroke', cssColor);
             if (typeof(annotationItem.svg) === "undefined" ) {
                 jQuery('.annotationModal.item-modal-' + annotationItem.id.toString() + ' .zoomToImageBounds img').css('border', '3px solid ' + cssColor);
@@ -874,6 +879,7 @@
         jQuery('.annotationModal #closeModal').focus();
         jQuery('.annotationModal #closeModal').click( function (e) {
             jQuery('.annotationModal').remove();
+            jQuery('.annotation-instructions').focus();
         });
     };
 

--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -512,6 +512,7 @@
                 section.css('right', '-5px');
                 jQuery('.modal-navigation').addClass('hidden'); 
                 jQuery('.editgroup').addClass('hidden');
+                jQuery('#hxat-alert').html('Sidebar has been hidden');
             } else {
                 AController.utils.logThatThing('toggled_sidebar', {'opening': true}, 'harvardx', 'hxat');
                 jQuery('#leftCol').attr('class', 'col-xs-7');
@@ -521,6 +522,7 @@
                 section.css('right', '0px');
                 jQuery('.modal-navigation').removeClass('hidden'); 
                 jQuery('.editgroup').removeClass('hidden');
+                jQuery('#hxat-alert').html('Sidebar is now being shown.');
             }
             handle.find('i').toggleClass('fa-arrow-right');
             handle.find('i').toggleClass('fa-arrow-left');
@@ -795,6 +797,7 @@
             onConfirm: function (){
                 if(annotationItem.authToDeleteButton) {
                     self.initOptions.endpoint.deleteAnnotation(annotation);
+                    jQuery('#hxat-alert').html('Annotation has been deleted');
                 }
             },
         });

--- a/hx_lti_initializer/static/TargetObjectController.js
+++ b/hx_lti_initializer/static/TargetObjectController.js
@@ -70,6 +70,7 @@
             Annotator._instances[0].destroy();
             AController.annotationCore.element = jQuery('.content');
             AController.annotationCore.init("text");
+            AController.annotationCore.annotation_tool.plugins.Store._getAnnotations();
         };
 
         // function from: http://stackoverflow.com/questions/4811822/get-a-ranges-start-and-end-offsets-relative-to-its-parent-container
@@ -221,6 +222,7 @@
         // deals with the button that turns on keyboard annotations
         jQuery('#make_annotations_panel button').click(function(){
             AController.utils.logThatThing('clicked_keyboard_input_button', {'media': 'text'}, 'harvardx', 'hxat');
+            AController.dashboardObjectController.endpoint._clearAnnotator();
             // if person is trying to start making an annotation via keyboard
             if (jQuery(this).attr('data-toggled') == "false") {
 
@@ -378,6 +380,7 @@
                     "parent": "0",
                     "media": "text",
                 };
+                AController.annotationCore.annotation_tool.setupAnnotation(window.savingAnnotation);
             } else {
                 clearKeyboardInput();
 
@@ -502,6 +505,7 @@
                 case 13:
                     toggleqtip();
                     jQuery('#keyboard-input-button').css('color', '#ffff00');
+                    jQuery('.openseadragon-canvas').focus();
                     break;
             }
         });

--- a/hx_lti_initializer/static/TargetObjectController.js
+++ b/hx_lti_initializer/static/TargetObjectController.js
@@ -228,15 +228,10 @@
 
                 // make the text editable and change UI to reflect change
                 jQuery('.content').attr('contenteditable', 'true');
-                jQuery(this).attr('data-toggled', 'true');
+                jQuery('#make_annotations_panel button').attr('data-toggled', 'true');
                 jQuery('.content').attr('role', 'textbox');
                 jQuery('.content').attr('tabindex', '0');
                 jQuery('.content').attr('aria-multiline', 'true');
-                jQuery(this).html("Save Highlights");
-                
-                // automatically bring person to beginning of target text
-                // this helps orient a person using a screen reader
-                jQuery('.content')[0].focus();
 
                 // makes sure that key count is set to 0 again so that you
                 // can only make two asterisks
@@ -311,6 +306,11 @@
                                 return false;
                             }
                             window.keyCount = window.keyCount+1;
+                            if (window.keyCount === 1) {
+                                jQuery('#hxat-alert').html('Asterisk added. Add one more to the text to make an annotation.');
+                            } else if (window.keyCount === 2) {
+                                jQuery('#hxat-alert').html('Annotation selection completed. Hit ENTER to save highlight or delete and replace asterisks to make a different selection.');
+                            }
                             break;
                         // Esc button
                         case 27:
@@ -339,6 +339,10 @@
 
                 // save the original content of the tool so you can set it back to normal later
                 window.originalContent = jQuery(AController.annotationCore.annotation_tool.wrapper[0]).html();
+                self.annotationsSaved = window.AController.annotationCore.annotation_tool.plugins.Store.annotations.slice();
+                window.AController.dashboardObjectController.endpoint._clearAnnotator();
+                jQuery('.content')[0].focus();
+
             } else if(jQuery(this).attr('data-toggled') == "true") {
                 // if user has submitted highlights
 
@@ -403,6 +407,17 @@
 
                 // this adds the annotation to the dashboard
                 AController.dashboardObjectController.annotationCreated(window.savingAnnotation);
+
+                // notifies user that annotation was created
+                jQuery('#hxat-status').html("Annotation was created. Visit the Annotation List Section to view it.");
+
+                var annotator = window.AController.annotationCore.annotation_tool;
+                var store = annotator.plugins.Store;
+                self.annotationsSaved.forEach(function (annotation) {
+                        annotator.setupAnnotation(annotation);
+                        store.registerAnnotation(annotation);
+                });
+                annotator.publish("externalCallToHighlightTags");
             }
         });
 
@@ -426,7 +441,120 @@
                 jQuery('#keyboard-input-toggle-text').css('color', '#FFFF00');
                 setTimeout(
                     function(){
-                        jQuery('#make_annotations_panel button')[0].focus();
+                        // make the text editable and change UI to reflect change
+                        jQuery('.content').attr('contenteditable', 'true');
+                        jQuery('#make_annotations_panel button').attr('data-toggled', 'true');
+                        jQuery('.content').attr('role', 'textbox');
+                        jQuery('.content').attr('tabindex', '0');
+                        jQuery('.content').attr('aria-multiline', 'true');
+                        
+                        // makes sure that key count is set to 0 again so that you
+                        // can only make two asterisks
+                        window.keyCount = 0;
+
+                        // in case this is not the first time that a person is making an annotation
+                        // via keyboard input, this unloads event. 
+                        jQuery('.content').off('keydown');
+                        jQuery('.content').on('keydown', function(event) {
+                            var keyCode = event.keyCode;
+                            // if you haven't already:
+                            event = event || window.event;
+
+                            switch(keyCode) {
+                                // left arrow key
+                                case 37:
+                                // up arrow key
+                                case 38:
+                                // right arrow key
+                                case 39:
+                                // bottom arrow key
+                                case 40:
+                                    // arrow keys should work normally
+                                    break;
+                                // backspace key
+                                case 8:
+
+                                    // make sure that item you are trying to backspace is the delimiter
+                                    // TODO: change this asterisk to delimiter
+                                        var deleted = jQuery('.content').text().charAt(getTextCursor(jQuery('.content')[0])-1) !== '*';
+                                        
+                                        // if it isn't an asterisk, prevent the user from deleting it
+                                        // likewise prevent them if they never even typed an asterisk in the first place
+                                        if (window.keyCount == 0 || deleted) {
+                                        // to cancel the event:
+                                        if( event.preventDefault) event.preventDefault();
+                                        return false;
+                                    } else {
+                                        window.keyCount = window.keyCount-1;
+                                    }
+                                    break;
+                                // delete key
+                                case 46:
+                                    // make sure item you are trying to [forward] delete is the delimiter
+                                    // TODO: change this asterisk to delimiter
+                                    var deleted = jQuery('.content').text().charAt(getTextCursor(jQuery('.content')[0])) !== '*';
+                                    
+                                    // like above, if it isn't an asterisk prevent user from deleting it
+                                    // likewise prevent them if they never even typed an asterisk in the first place
+                                    if (window.keyCount == 0 || deleted) {
+                                        // to cancel the event:
+                                        if( event.preventDefault) event.preventDefault();
+                                        return false;
+                                    } else {
+                                        window.keyCount = window.keyCount-1;
+                                    }
+                                    break;
+                                // 8/* button
+                                case 56:
+
+                                    // if person hit 8 and not * then prevent them from doing so
+                                    if (!event.shiftKey) {
+                                        // to cancel the event:
+                                        if( event.preventDefault) event.preventDefault();
+                                        return false;
+                                    }
+
+                                    // likewise prevent the if they were trying to add more than 2 delimiters
+                                    if (window.keyCount == 2) {
+                                        // to cancel the event:
+                                        if( event.preventDefault) event.preventDefault();
+                                        return false;
+                                    }
+                                    window.keyCount = window.keyCount+1;
+                                    if (window.keyCount === 1) {
+                                        jQuery('#hxat-alert').html('Asterisk added. Add one more to the text to make an annotation.');
+                                    } else if(window.keyCount === 2) {
+                                        jQuery('#hxat-alert').html('Annotation selection completed. Hit ENTER to save highlight or delete and replace asterisks to make a different selection.');
+                                    }
+                                    break;
+                                // Esc button
+                                case 27:
+                                    // sets the target text back to normal and erases delimiter marks
+                                    clearKeyboardInput();
+                                    break;
+                                // Enter button
+                                case 13:
+                                    // submits highlights like pressing the "Save Highlights" button
+                                    jQuery('#make_annotations_panel button').click();
+                                    return false;
+                                // Tab button
+                                case 9:
+                                    // moves it to the "Save Highlights" button
+                                    jQuery('#make_annotations_panel button')[0].focus();
+                                    return false;
+                                default:
+                                    // to cancel the event:
+                                    if( event.preventDefault) event.preventDefault();
+                                    return false;
+                            }
+                        });
+
+                        // save the original content of the tool so you can set it back to normal later
+                        window.originalContent = jQuery(AController.annotationCore.annotation_tool.wrapper[0]).html();
+                        self.annotationsSaved = window.AController.annotationCore.annotation_tool.plugins.Store.annotations.slice();
+                        window.AController.dashboardObjectController.endpoint._clearAnnotator();
+                        jQuery('.content')[0].focus();
+                        jQuery('#hxat-status').html('Keyboard input is enabled. JAWS Users and newcomers should visit Instructions to Make Annotations Using Keyboard Input section if you need help.');
                     }, 
                 500);
             }
@@ -948,7 +1076,7 @@
                                 }
                             });
                         });
-                    }
+                    };
 
                     jQuery.each(AController.dashboardObjectController.endpoint.annotationsMasterList, function(index, value) {
                         if (annotationId == value.id) {
@@ -968,14 +1096,14 @@
                                             checkDrawnOutlines(value1.selector.item['value']);
                                         }
                                     }
-                                })
+                                });
                             } else {
                                 setTimeout(function() {jQuery('.annotationItem.item-' + annotationId.toString() + ' .zoomToImageBounds img').css('border', '3px solid ' + rgbHex), 500});
                             }
                         }
                     });
                 }, 30);
-            };
+            }
         };
 
         $.TargetObjectController.prototype.colorizeViewer = function (){
@@ -985,7 +1113,7 @@
                 var rgbColor = window.AController.main.tags[tag];
                 if (rgbColor !== undefined) {
                         jQuery(item).css("background-color", "rgba(" + rgbColor.red + ", " + rgbColor.green + ", " + rgbColor.blue + ", " + rgbColor.alpha + ")");
-                };
+                }
             });
         };
 
@@ -1008,6 +1136,7 @@
                     jQuery('#annotations-status .labeltext').html("Show annotations");
                     jQuery('#annotations-status').attr('aria-label', "Show annotations");
                     jQuery('#annotations-status i').removeClass('fa-close').addClass('fa-comments');
+                    jQuery('#hxat-status').html('Annotations have been hidden.');
                     this.annotationsSaved = store.annotations.slice();
                     window.AController.dashboardObjectController.endpoint._clearAnnotator();
                     AController.utils.logThatThing('toggle_annotations_display', {'status': 'hidden'}, 'harvardx', 'hxat');
@@ -1015,9 +1144,10 @@
                     jQuery('#annotations-status .labeltext').html("Hide annotations");
                     jQuery('#annotations-status').attr('aria-label', "Hide annotations");
                     jQuery('#annotations-status i').addClass('fa-close').removeClass('fa-comments');
+                    jQuery('#hxat-status').html('Annotations are being shown.');
                     this.annotationsSaved.forEach(function (annotation) {
-                            annotator.setupAnnotation(annotation);
-                            store.registerAnnotation(annotation);
+                        annotator.setupAnnotation(annotation);
+                        store.registerAnnotation(annotation);
                     });
                     annotator.publish("externalCallToHighlightTags");
                     AController.utils.logThatThing('toggle_annotations_display', {'status': 'shown'}, 'harvardx', 'hxat');

--- a/hx_lti_initializer/static/accessibility.js
+++ b/hx_lti_initializer/static/accessibility.js
@@ -1,0 +1,71 @@
+//accessibility.js
+
+(function($) {
+	$.Accessibility = function(options) {
+		this.initOptions = options;
+		this.init();
+		return this;
+	};
+
+	$.Accessibility.prototype.init = function() {
+		var self = this;
+		jQuery.each(this.initOptions['triggerClicks'], function(index, value) {
+			self.keyPressOn('body', value, {
+				'13': function(){
+					jQuery(event.target).trigger('click');
+				}, 
+				'32': function() {
+					jQuery(event.target).trigger('click');
+				}
+			})
+		})
+	};
+
+	// if you need something that works in the document/window without a specific element
+	$.Accessibility.prototype.globalKeyPress = function(codesAndFuncs) {
+		var self = this;
+		jQuery(document).ready(function() {
+			jQuery(this).on('keypress', function(event) {
+				var key = event.keyCode ? event.keyCode : event.which;
+				jQuery.each(codesAndFuncs, function(keyCode, value) {
+					if (key == self.keyCodeValue(keyCode)) {
+						value();
+					}
+				});
+				return false;
+			});
+		});
+	};
+
+	// if you need a listener when focused on a specific element
+	$.Accessibility.prototype.keyPressOn = function(parent, child, codesAndFuncs) {
+		var self = this;
+		jQuery(parent).on('keypress', child, function(event) {
+			var key = event.keyCode ? event.keyCode : event.which;
+			jQuery.each(codesAndFuncs, function(keyCode, value) {
+				if (key == self.keyCodeValue(keyCode)) {
+					value();
+				}
+			});
+			return false;
+		});
+	};
+
+	// translates keyCodeValue ... will add more as more are needed
+	$.Accessibility.prototype.keyCodeValue = function(keyCode) {
+		switch(keyCode.toUpperCase()) {
+			case 'SPACE':
+			case 'SPACEBAR':
+			case 'SPACE BAR':
+				return 32;
+				break;
+			case 'ENTER':
+			case 'ENT':
+				return 13;
+				break;
+			default:
+				return parseInt(keyCode, 10);
+		}
+	};
+
+}(AController))

--- a/hx_lti_initializer/static/css/base.css
+++ b/hx_lti_initializer/static/css/base.css
@@ -454,7 +454,7 @@ footer {
 	font-weight: bold;
 }
 
-.form-group label.course_name, .edit_course_subheading, .subheading {
+.form-group label.course_name, .edit_course_subheading, .subheading, .form-group label.edit_course_subheading {
 	font-size: 11pt;
 	color: rgb(107, 107, 107);
 	font-weight:normal;
@@ -677,7 +677,7 @@ p.help {
 
 .save#save-button, .save#annotation-settings-save-button, .save#database-settings-cancel-button, .save#source-save-button, .save#import-button {
 	color: white;
-	background-color: rgb(55, 124, 182);
+	background-color: #285b85;
 }
 
 .save#save-button:hover, .save#annotation-settings-save-button:hover, .save#database-settings-cancel-button:hover, .save#source-save-button:hover, .save#import-button:hover {
@@ -827,6 +827,7 @@ p.help {
 
 #create-new-source-button {
 	margin-left: 10px;
+	color: #1f496e;
 }
 
 .source-detail {
@@ -1304,4 +1305,5 @@ progress[value]::-webkit-progress-value {
 
 .make-starting-resource {
 	text-decoration: none;
+	cursor: pointer;
 }

--- a/hx_lti_initializer/static/css/dashboard.css
+++ b/hx_lti_initializer/static/css/dashboard.css
@@ -300,6 +300,12 @@ button#hideParent {
 	float: right;
 }
 
+.offscreen {
+    position: absolute;
+    top: -9999999999999;
+    left: -999999999999;
+}
+
 .annotationModal .idAnnotation {
 	display: none;
 }

--- a/hx_lti_initializer/static/templates/dashboard/annotationItem_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/annotationItem_side.html
@@ -45,8 +45,13 @@
     </div>
     <% if (typeof tags !== "undefined") { %>
         <div class="tagList field side">
-            <% _.each(tags, function(tagItem){ %>
-                <div class="tag side" aria-label="tag: <%- tagItem.replace(/"/g, '&quot;') %>">
+            <% _.each(tags, function(tagItem) { %>
+                <% var style = ""; %>
+                <% if (window.AController.main.tags[tagItem] !== undefined) { %>
+                        <% var rgbColor = window.AController.main.tags[tagItem]; %>
+                        <% style = "style=\"background-color:rgba(" + rgbColor.red + ", " + rgbColor.green + ", " + rgbColor.blue + ", " + rgbColor.alpha + ")\""; %>
+                <% }; %>
+                <div class="tag side" <%= style %> aria-label="Tag: <%- tagItem.replace(/"/g, '&quot;') %>">
                     <%= tagItem %>
                 </div>
             <% }); %>

--- a/hx_lti_initializer/static/templates/dashboard/annotationItem_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/annotationItem_side.html
@@ -39,7 +39,7 @@
         <% } %>
     </div>
     
-    <div class="totalreplies field side clicking_allowed" tabindex="0"> role="button" aria-label="Make or view replies Annotation #<%=index %>">
+    <div class="totalreplies field side clicking_allowed" tabindex="0" role="button" aria-label="Make or view replies Annotation #<%=index %>">
         <span class="glyphicon glyphicon-comment"></span>
         <span class="replyNum"> <%= totalComments %> </span>
     </div>

--- a/hx_lti_initializer/static/templates/dashboard/annotationItem_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/annotationItem_side.html
@@ -16,7 +16,7 @@
         </div>
     <% } else if (media === 'image' && thumbnail) {%>
         <div class="zoomToImageBounds" style='position:relative;'>
-            <img class="annotation-thumbnail" src="/static/css/images/loading.gif" data-src="<%= thumbnail %>" onError="this.onerror=null;this.src='/static/css/images/image-error.png';" data-svg=".thumbnail-<%= id %>"/>
+            <img class="annotation-thumbnail" src="/static/css/images/loading.gif" data-src="<%= thumbnail %>" onError="this.onerror=null;this.src='/static/css/images/image-error.png';" data-svg=".thumbnail-<%= id %>" alt="Thumbnail Preview"/>
             <% if (typeof(svg) !== "undefined") { %>
                 <%= svg %>
             <% } %>
@@ -39,7 +39,7 @@
         <% } %>
     </div>
     
-    <div class="totalreplies field side" role="button" aria-label="Make or view replies Annotation #<%=index %>">
+    <div class="totalreplies field side clicking_allowed" tabindex="0"> role="button" aria-label="Make or view replies Annotation #<%=index %>">
         <span class="glyphicon glyphicon-comment"></span>
         <span class="replyNum"> <%= totalComments %> </span>
     </div>

--- a/hx_lti_initializer/static/templates/dashboard/annotationModal_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/annotationModal_side.html
@@ -22,7 +22,7 @@
         </div>
     	<% } else if (media === 'image' && thumbnail) {%>
 	    <div class="zoomToImageBounds">
-	    	<img class="annotation-thumbnail" src="<%= thumbnail %>" data-svg='.thumbnail-<%= id %>' />
+	    	<img class="annotation-thumbnail" src="<%= thumbnail %>" data-svg='.thumbnail-<%= id %>' alt="Thumbnail Preview" />
 	    	<% if (typeof(svg) !== "undefined") { %>
 	    		<%= svg %>
 	    	<% } %>
@@ -30,7 +30,7 @@
             <span class="uri" style="display:none"><%= uri %></span>
         </div>
 	    <% } else if (media === "video") {%>
-        <div class="playMediaButton" style="text-align:center;">
+        <div class="playMediaButton clicking_allwed" tabindex="0" style="text-align:center;">
             <div class="btn btn-default" role="button" style="text-align:center;margin-top:20px">
                 Play Segment <%= rangeTime.start %> - <%= rangeTime.end %>
             </div>

--- a/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/annotationSection_side.html
@@ -2,7 +2,7 @@
     <!--<div class="handle-button" title="Hide/Show dashboard" aria-labeledby="sidebar-hide-sidebar-instructions" role="button"><i class="fa fa-arrow-right"></i></div>-->
 </div>
 <div class="annotationSection side">
-    <div class="annotation-instructions" role="button" aria-labeledby="sidebar-annotations-instructions">
+    <div class="annotation-instructions clicking_allowed" tabindex="0" role="button" aria-labeledby="sidebar-annotations-instructions">
             <img src="/static/css/images/info28.png" alt="Show annotation instructions" style="width: 20px;height: 20px; float: right;" aria-labeledby="sidebar-annotations-instructions"/>  
         </div>
         <div class="title" id="sidebar-annotations-instructions">View Annotation Instructions</div>

--- a/hx_lti_initializer/static/templates/dashboard/replyItem_side.html
+++ b/hx_lti_initializer/static/templates/dashboard/replyItem_side.html
@@ -1,4 +1,4 @@
-<div class="replyItem item-<%= id%> side" role="listitem" aria-label="Reply to annotation">
+<div class="replyItem item-<%= id%> side" tabindex="0" role="listitem" aria-label="Reply to annotation">
 	<span class="idAnnotation"><%= id %></span>
 
 	 <div class="replytext field side">

--- a/hx_lti_initializer/static/vendors/Annotator/annotator-full.js
+++ b/hx_lti_initializer/static/vendors/Annotator/annotator-full.js
@@ -1045,7 +1045,7 @@
       root = this.wrapper[0];
       annotation.ranges || (annotation.ranges = this.selectedRanges);
       normedRanges = [];
-      _ref1 = annotation.range || [];
+      _ref1 = annotation.ranges || [];
       for (_k = 0, _len2 = _ref1.length; _k < _len2; _k++) {
         r = _ref1[_k];
         try {

--- a/hx_lti_initializer/static/vendors/Annotator/annotator-full.js
+++ b/hx_lti_initializer/static/vendors/Annotator/annotator-full.js
@@ -1045,7 +1045,7 @@
       root = this.wrapper[0];
       annotation.ranges || (annotation.ranges = this.selectedRanges);
       normedRanges = [];
-      _ref1 = annotation.ranges;
+      _ref1 = annotation.range || [];
       for (_k = 0, _len2 = _ref1.length; _k < _len2; _k++) {
         r = _ref1[_k];
         try {

--- a/hx_lti_initializer/static/vendors/Annotator/plugins/summernote-richtext-annotator.js
+++ b/hx_lti_initializer/static/vendors/Annotator/plugins/summernote-richtext-annotator.js
@@ -33,6 +33,8 @@ Annotator.Plugin.SummernoteRichText.prototype.pluginInit = function() {
 	self.annotator.subscribe("annotationEditorShown", function() {
 		// checks to make sure it can fit on screen
 		$('#annotator-field-0').summernote(self.options);
+		delete $.summernote.options.keyMap.pc.TAB;
+		delete $.summernote.options.keyMap.mac.TAB;
 		self.checkOrientation();
 
 		// then it will restart summernote, otherwise it may cause all <li> to have Save

--- a/hx_lti_initializer/static/vendors/development/videojs-annotator-plugin.js
+++ b/hx_lti_initializer/static/vendors/development/videojs-annotator-plugin.js
@@ -753,8 +753,9 @@ Util.mousePosition = function(e, offsetEl) {
 
     videojs.ShowStatistics.prototype.createEl = function() {
         return videojs.Button.prototype.createEl.call(this, 'div', {
-            className: 'vjs-statistics-annotation vjs-control',
+            className: 'vjs-statistics-annotation allow_clicking vjs-control',
             title: 'Show the Statistics',
+            tabindex: '0',
         });
     };
 
@@ -787,8 +788,9 @@ Util.mousePosition = function(e, offsetEl) {
 
     videojs.ShowAnnotations.prototype.createEl = function() {
         return videojs.Button.prototype.createEl.call(this, 'div', {
-            className: 'vjs-showannotations-annotation vjs-control',
+            className: 'vjs-showannotations-annotation allow_clicking vjs-control',
             title: 'Show Annotations',
+            tabindex: '0',
         });
     };
 
@@ -824,8 +826,9 @@ Util.mousePosition = function(e, offsetEl) {
 
     videojs.NewAnnotation.prototype.createEl = function() {
         return videojs.Button.prototype.createEl.call(this, 'div', {
-            className: 'vjs-new-annotation vjs-control',
+            className: 'vjs-new-annotation allow_clicking vjs-control',
             title: 'New Annotation',
+            tabindex: '0'
         });
     };
 

--- a/hx_lti_initializer/static/vendors/development/vjs.youtube.js
+++ b/hx_lti_initializer/static/vendors/development/vjs.youtube.js
@@ -65,6 +65,7 @@ videojs.Youtube = videojs.MediaTechController.extend({
       marginWidth: 0,
       marginHeight: 0,
       frameBorder: 0,
+      title:'Youtube Video',
       webkitAllowFullScreen: 'true',
       mozallowfullscreen: 'true',
       allowFullScreen: 'true'

--- a/hx_lti_initializer/static/vendors/mirador/mirador.js
+++ b/hx_lti_initializer/static/vendors/mirador/mirador.js
@@ -30999,11 +30999,13 @@ this._cbs.ontext(data)}};Tokenizer.prototype.reset=function(){Tokenizer.call(thi
     getAnnotationInEndpoint: function(oaAnnotation) {
       var _this = this,
       uris = [];
-      oaAnnotation.on.forEach(function(value) {
-        if (jQuery.inArray(value.full, uris) === -1) {
-          uris.push(value.full);
-        }
-      });
+      if (jQuery.isArray(oaAnnotation)) {
+	      oaAnnotation.on.forEach(function(value) {
+	        if (jQuery.inArray(value.full, uris) === -1) {
+	          uris.push(value.full);
+	        }
+	      });
+	  }
       var annotations = [];
 
       uris.forEach(function(uri) {
@@ -37706,14 +37708,14 @@ bindEvents: function() {
                                  '<div class="mirador-osd-context-controls hud-container">',
                                  '{{#if showAnno}}',
                                   '<div class="mirador-osd-annotation-controls">',
-                                  '<a class="mirador-osd-annotations-layer hud-control" role="button" title="{{t "annotationTooltip"}}" aria-label="{{t "annotationTooltip"}}">',
+                                  '<a class="mirador-osd-annotations-layer hud-control clicking_allowed" tabindex="0" role="button" title="{{t "annotationTooltip"}}" aria-label="{{t "annotationTooltip"}}">',
                                   '<i class="fa fa-lg fa-comments"></i>',
                                   '</a>',
                                   '</div>',
                                  '{{/if}}',
                                  '{{#if showImageControls}}',
                                   '<div class="mirador-manipulation-controls">',
-                                  '<a class="mirador-manipulation-toggle hud-control" role="button" title="{{t "imageManipulationTooltip"}}" aria-label="{{t "imageManipulationTooltip"}}">',
+                                  '<a class="mirador-manipulation-toggle hud-control clicking_allowed" tabindex="0" role="button" title="{{t "imageManipulationTooltip"}}" aria-label="{{t "imageManipulationTooltip"}}">',
                                   '<i class="material-icons">tune</i>',
                                   '</a>',
                                   '</div>',
@@ -37725,30 +37727,30 @@ bindEvents: function() {
                                  '</a>',
                                  '{{/if}}',
                                  '{{#if showBottomPanel}}',
-                                 '<a class="mirador-osd-toggle-bottom-panel hud-control" role="button" aria-label="Toggle Bottom Panel">',
+                                 '<a class="mirador-osd-toggle-bottom-panel hud-control clicking_allowed" tabindex="0" role="button" aria-label="Toggle Bottom Panel">',
                                  '<i class="fa fa-2x fa-ellipsis-h"></i>',
                                  '</a>',
                                  '{{/if}}',
                                  '<div class="mirador-pan-zoom-controls hud-control">',
-                                 '<a class="mirador-osd-up hud-control" role="button" aria-label="Move image up">',
+                                 '<a class="mirador-osd-up hud-control clicking_allowed" tabindex="0" role="button" aria-label="Move image up">',
                                  '<i class="fa fa-chevron-circle-up"></i>',
                                  '</a>',
-                                 '<a class="mirador-osd-right hud-control" role="button" aria-label="Move image right">',
+                                 '<a class="mirador-osd-right hud-control clicking_allowed" tabindex="0" role="button" aria-label="Move image right">',
                                  '<i class="fa fa-chevron-circle-right"></i>',
                                  '</a>',
-                                 '<a class="mirador-osd-down hud-control" role="button" aria-label="Move image down">',
+                                 '<a class="mirador-osd-down hud-control clicking_allowed" tabindex="0" role="button" aria-label="Move image down">',
                                  '<i class="fa fa-chevron-circle-down"></i>',
                                  '</a>',
-                                 '<a class="mirador-osd-left hud-control" role="button" aria-label="Move image left">',
+                                 '<a class="mirador-osd-left hud-control clicking_allowed" tabindex="0" role="button" aria-label="Move image left">',
                                  '<i class="fa fa-chevron-circle-left"></i>',
                                  '</a>',
-                                 '<a class="mirador-osd-zoom-in hud-control" role="button" aria-label="Zoom in">',
+                                 '<a class="mirador-osd-zoom-in hud-control clicking_allowed" tabindex="0" role="button" aria-label="Zoom in">',
                                  '<i class="fa fa-plus-circle"></i>',
                                  '</a>',
-                                 '<a class="mirador-osd-zoom-out hud-control" role="button" aria-label="Zoom out">',
+                                 '<a class="mirador-osd-zoom-out hud-control clicking_allowed" tabindex="0" role="button" aria-label="Zoom out">',
                                  '<i class="fa fa-minus-circle"></i>',
                                  '</a>',
-                                 '<a class="mirador-osd-go-home hud-control" role="button" aria-label="Reset image bounds">',
+                                 '<a class="mirador-osd-go-home hud-control clicking_allowed" tabindex="0" role="button" aria-label="Reset image bounds">',
                                  '<i class="fa fa-home"></i>',
                                  '</a>',
                                  '</div>',

--- a/hx_lti_initializer/static/vendors/mirador/mirador.js
+++ b/hx_lti_initializer/static/vendors/mirador/mirador.js
@@ -30999,7 +30999,7 @@ this._cbs.ontext(data)}};Tokenizer.prototype.reset=function(){Tokenizer.call(thi
     getAnnotationInEndpoint: function(oaAnnotation) {
       var _this = this,
       uris = [];
-      if (jQuery.isArray(oaAnnotation)) {
+      if (jQuery.isArray(oaAnnotation.on)) {
 	      oaAnnotation.on.forEach(function(value) {
 	        if (jQuery.inArray(value.full, uris) === -1) {
 	          uris.push(value.full);

--- a/hx_lti_initializer/templates/hx_lti_initializer/admin_hub.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/admin_hub.html
@@ -51,13 +51,13 @@
                         {% for file in assignment.assignment_objects.all|order_by:"assignmenttargets" %}
                             <div class='table-row'>
                                 {% if is_instructor %}
-                                <a href='#' class='make-starting-resource' data-url="{% url 'hx_lti_initializer:change_starting_resource' assignment_id=assignment.assignment_id object_id=file.id %}?resource_link_id={{resource_link_id}}" data-title='{{file.target_title}}'>
+                                <span href='#' class='make-starting-resource' data-url="{% url 'hx_lti_initializer:change_starting_resource' assignment_id=assignment.assignment_id object_id=file.id %}?resource_link_id={{resource_link_id}}" data-title='{{file.target_title}}'>
                                     {% if assignment.assignment_id == starter_collection_id and file.id == starter_object_id %}
                                     <i class='fa fa-check-square'></i>
                                     {% else %}
                                     <i class='fa fa-square-o'></i>
                                     {% endif %}
-                                </a>
+                                </span>
                                 {% endif %}
                                 <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course.course_id assignment_id=assignment.assignment_id object_id=file.id %}?resource_link_id={{resource_link_id}}&{{utm_source_param}}">{{file.target_title}}</a>
                                 {% if is_instructor %}

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -59,13 +59,13 @@
             {% endif %}
             <div class="pagination">
                 {% if prev_object %}
-                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=prev_object.target_object.id %}?resource_link_id={{resource_link_id}}&utm_source={{utm_source}}" class="btn btn-default" role="button" onclick="AController.utils.logThatThing('clicked_previous_source_button', {}, 'harvardx', 'hxat');" id="prev_target_object" aria-label="Move to previous document"><i class="glyphicon glyphicon-chevron-left"></i> Previous</a>
+                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=prev_object.target_object.id %}?utm_source={{utm_source}}&resource_link_id={{resource_link_id}}" class="btn btn-default" tabindex="0" role="button" onClick="AController.utils.logThatThing('clicked_previous_source_button', {}, 'harvardx', 'hxat');" id="prev_target_object" aria-label="Move to previous document"><i class="glyphicon glyphicon-chevron-left"></i> Previous</a>
                 {% endif %}
                 {% if prev_object or next_object %}
                     <div class="pages" aria-label="You are in document {{assignment_target.order}} out of {{assignment.assignment_objects.count}}.">{{assignment_target.order}} / {{ assignment.assignment_objects.count }}</div>
                 {% endif %}
                 {% if next_object %}
-                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=next_object.target_object.id %}?resource_link_id={{resource_link_id}}&utm_source={{utm_source}}" class="btn btn-default" onclick="AController.utils.logThatThing('clicked_next_source_button', {}, 'harvardx', 'hxat');" role="button" id="next_target_object" aria-label="Move to next document">Next <i class="glyphicon glyphicon-chevron-right"></i></a><br />
+                    <a href="{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=next_object.target_object.id %}?utm_source={{utm_source}}&resource_link_id={{resource_link_id}}" class="btn btn-default" tabindex="0" onClick="AController.utils.logThatThing('clicked_next_source_button', {}, 'harvardx', 'hxat');" role="button" id="next_target_object" aria-label="Move to next document">Next <i class="glyphicon glyphicon-chevron-right"></i></a><br />
                 {% endif %}
             </div>
             
@@ -83,7 +83,7 @@
 
         {% block mainapplication %}{% endblock %}
 
-        <section role="application" aria-label="Annotation Tool | Annotations List">
+        <section role="complimentary" aria-label="Annotation Tool | Annotations List">
             <div id="dashboard" class="annotationListContainer"></div>
         </section>
     </div>

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -83,7 +83,7 @@
 
         {% block mainapplication %}{% endblock %}
 
-        <section role="complimentary" aria-label="Annotation Tool | Annotations List">
+        <section role="complementary" aria-label="Annotation Tool | Annotations List">
             <div id="dashboard" class="annotationListContainer"></div>
         </section>
     </div>

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -39,6 +39,7 @@
         <script src="{% static "DashboardView.js" %}"></script>
         <script src="{% static "TargetObjectController.js" %}"></script>
         <script src="{% static "utilities.js" %}"></script>
+        <script src="{% static "accessibility.js" %}"></script>
 
         {# stylesheet for icons, dashboard and instructions #}
         <link rel="stylesheet" href="{% static "vendors/development/css/font-awesome.css" %}">
@@ -68,16 +69,16 @@
                 {% endif %}
             </div>
             
-            <div class="annotation-fullscreen" role="button" aria-label="Toggle Fullscreen Mode">
+            <div class="annotation-fullscreen clicking_allowed" tabindex="0" role="button" aria-label="Toggle Fullscreen Mode">
                 <i class="fa fa-expand"></i>
             </div>
             {% block keyboardinput %}{% endblock %}
             {% if org == "HARVARDX" %}
                 <div class="logo" aria-label="HarvardX Logo">
-                    <img src="{% static "css/images/hx_inv.png" %}" style="height:40px;" />
+                    <img src="{% static "css/images/hx_inv.png" %}" style="height:40px;" alt="HarvardX Logo" />
                 </div>
             {% endif %}
-            <div class="handle-button" title="Hide/Show dashboard" aria-labeledby="sidebar-hide-sidebar-instructions" role="button"><i class="fa fa-navicon"></i></div>
+            <div class="handle-button clicking_allowed" tabindex="0" title="Hide/Show dashboard" aria-labeledby="sidebar-hide-sidebar-instructions" role="button"><i class="fa fa-navicon"></i></div>
         </nav>
 
         {% block mainapplication %}{% endblock %}

--- a/hx_lti_initializer/templates/hx_lti_initializer/edit_course.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/edit_course.html
@@ -53,10 +53,11 @@
 		<!-- TODO: Add example of how to use-->
 		<h4 class='edit_course_subheading'>External CSS Default:</h4>
 		<div class="form-group">
+			<label for="id_course_external_css_default" class="edit_course_subheading">External CSS Default:</label>
 			<input id="id_course_external_css_default" maxlength="255" name="course_external_css_default" class="form-control hx-textfield" type="text" value="{{form.course_external_css_default.value}}">
 		</div>
 		<div class='button-collection'>
-			<div type="submit" class="save" id='save-button' role="button" onclick="javascript:jQuery('#edit_course_form').submit();">
+			<div type="submit" class="save" id='save-button' tabindex="0" role="button" onclick="javascript:jQuery('#edit_course_form').submit();">
 			Save
 			</div>
 			<div class="save" id='cancel-button' role='button' onclick='window.location="{% url 'hx_lti_initializer:course_admin_hub' %}?resource_link_id={{ resource_link_id }}";'>
@@ -77,6 +78,9 @@
 				  jQuery('#ro-course-admins').html(oldValue);
 				});
 				jQuery('#ro-course-admins').html(jQuery('.dropdown-toggle[data-id="id_select_existing_user"] span').html());
+				jQuery('.save').on('keyup', function (e){ if (e.which === 32 || e.which === 13){
+                    jQuery(e.currentTarget).click();} 
+                });
 			}, 1000);
 			setTimeout(function(){
 				if (window.navigator.platform === "Win32") {

--- a/hx_lti_initializer/templates/ig/detail.html
+++ b/hx_lti_initializer/templates/ig/detail.html
@@ -37,6 +37,10 @@
 
 {% block mainapplication %}
 <section role="main" aria-label="Annotation Tool Image Content" style="position:absolute; top:50px; height: 100%; height: calc(100% - 50px);">
+  <h3 class='offscreen'>Image to be Annotated</h3>
+  <div id="text-content-notifications" aria-live="assertive"></div>
+  <div id="hxat-status" role="alert"></div>
+  <div id="hxat-alert" role="alert"></div>
   <div id="viewer" class="test">
   </div>
 </section>

--- a/hx_lti_initializer/templates/ig/detail.html
+++ b/hx_lti_initializer/templates/ig/detail.html
@@ -36,7 +36,7 @@
 {% endblock %}
 
 {% block mainapplication %}
-<section role="application" aria-label="Annotation Tool Image Content" style="position:absolute; top:50px; height: 100%; height: calc(100% - 50px);">
+<section role="main" aria-label="Annotation Tool Image Content" style="position:absolute; top:50px; height: 100%; height: calc(100% - 50px);">
   <div id="viewer" class="test">
   </div>
 </section>

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -79,11 +79,11 @@ Annotation Tool | Text | {{ target_object.target_title }}
             </div>
             <div class="btn-group" role="group" aria-label="Control Annotation Text Size" aria-live="polite" >
                 <div class="pull-left" style="padding: 6px 12px;">Text Size <span id="annotations-text-size-label"></span>:</div>
-                <button id="annotations-text-size-plus" type="button" class="btn btn-default" role="button">
-                    <i class="fa fa-plus" aria-hidden="true" aria-label="Increase font size"></i>
+                <button aria-label="Increase font size" id="annotations-text-size-plus" type="button" class="btn btn-default" role="button">
+                    <i class="fa fa-plus" aria-hidden="true"></i>
                 </button>
-                <button id="annotations-text-size-minus" type="button" class="btn btn-default" role="button">
-                    <i class="fa fa-minus" aria-hidden="true" aria-label="Decrease font size"></i>
+                <button aria-label="Decrease font size" id="annotations-text-size-minus" type="button" class="btn btn-default" role="button">
+                    <i class="fa fa-minus" aria-hidden="true"></i>
                 </button>
             </div>
         </div>

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -46,7 +46,7 @@ Annotation Tool | Text | {{ target_object.target_title }}
 {% endblock %}
 
 {% block mainapplication %}
-<section role="application" aria-label="Annotation Tool Text Content">
+<section role="main" aria-label="Annotation Tool Text Content">
 	<div  id="viewer" class="test" style="padding:50px 75px;" class="fit-to-canvas">
         <div class="btn-toolbar target-object-controls" role="toolbar" aria-label="Annotation toolbar controls">
             <div class="btn-group" role="group" aria-label="Hide or Show Annotations">

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -47,7 +47,31 @@ Annotation Tool | Text | {{ target_object.target_title }}
 
 {% block mainapplication %}
 <section role="main" aria-label="Annotation Tool Text Content">
+  <h3 class='offscreen'>Text to be Annotated</h3>
+  <div id="text-content-notifications" aria-live="assertive"></div>
+  <div id="hxat-status" role="alert"></div>
+  <div id="hxat-alert" role="alert"></div>
 	<div  id="viewer" class="test" style="padding:50px 75px;" class="fit-to-canvas">
+        <section id="make_annotations_panel" class="hidden" role="region" aria-label="Make annotations using keyboard input">
+        <h3>Instructions to Make Annotations using Keyboard Input</h3>
+          <ol>
+            <li>Move to the beginning of the text to be anotated.</li>
+            <li>Once over the text, JAWS users should click the "Left Button Key" on your keyboard, FORWARDSLASH on the NUMPAD is the default. (Note: JAWS may only read out the first and last lines of the text until you've hit the "Left Button Key")</li>
+            <li>Add an asterisk before the text you want to annotate.</li>
+            <li>Add an asterisk after the text to mark the ending of the annotation. (Note: you are only allowed 2 asterisks at a time, so make one annotation at a time).</li>
+            <li>Hit ENTER to confirm your selection and move towards the text fields to enter your comments and tags.</li>
+          </ol>
+          <div class="hidden" id="annotation-maker">
+            <label for="id_annotation_text_screen_reader">Enter annotation for highlighted section:
+                <input type="text" id="id_annotation_text_screen_reader"/>
+            </label>
+            <label for="id_annotation_tag_screen_reader">Enter tags for this annotation (separate tags with a single space):
+              <input type="text" id="id_annotation_tag_screen_reader" />
+            </label>
+          </div>
+          <button role="button" class="btn btn-default" data-toggled="false">Save Highlights</button>
+      </section>
+   <div class="annotations-status on" role="button" aria-label="Toggle Annotations over content"><i class="fa fa-close"></i> <span role="tooltip" id="annotations-status-label" class="hover-inst hidden">Hide Annotations</span></div>
         <div class="btn-toolbar target-object-controls" role="toolbar" aria-label="Annotation toolbar controls">
             <div class="btn-group" role="group" aria-label="Hide or Show Annotations">
                 <button id="annotations-status" type="button" class="btn btn-default on" aria-label="Hide Annotations">
@@ -72,27 +96,14 @@ Annotation Tool | Text | {{ target_object.target_title }}
           	</div>
         	<section class="instructions-body collapse in" aria-expanded="true" aria-live="polite" id="annotation-instructions">{{instructions | safe}}</section>
         </div>
-        <h3>{{ target_object.target_title | safe }}</h3>
+        <h4>{{ target_object.target_title | safe }}</h4>
 	    {% if target_object.target_author != "None" %}
-		    <h4>by {{ target_object.target_author | safe }}</h4>
+		    <div class="author-label">by {{ target_object.target_author | safe }}</div>
 	    {% endif %}
 	    <div class="content">
 		    {{ target_object.target_content | safe }}
 	    </div>
-    
-	    <section id="make_annotations_panel" class="hidden" role="region" aria-label="Make annotations using keyboard input">
-	    	<h3>Make Annotations using Keyboard input</h3>
-      		<div aria-label="Read instructions on making annotation:">To make an annotation, click the "Make an Annotation" button. You will be taken to back to the content where you can add an asterisk (*) to the beginning and an asterisk(*) to the end of the area you would like to select. Make sure not to edit any other parts of the text! Then hit the "Save Highlights" button. Warning: this will turn off selection using the mouse to make annotations.</div>
-      		<div class="hidden" id="annotation-maker">
-        		<label for="id_annotation_text_screen_reader">Enter annotation for highlighted section:
-          			<input type="text" id="id_annotation_text_screen_reader"/>
-        		</label>
-		        <label for="id_annotation_tag_screen_reader">Enter tags for this annotation (separate tags with a single space):
-		        	<input type="text" id="id_annotation_tag_screen_reader" />
-		        </label>
-      		</div>
-      		<button role="button" class="btn btn-default" data-toggled="false">Make an annotation</button>
-	    </section>
+
 	    {% if target_object.target_citation != "None" %}
     		<div class="citation" style="margin-top:20px;">
     			<i>{{ target_object.target_citation }}</i>

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -42,7 +42,7 @@ Annotation Tool | Text | {{ target_object.target_title }}
 {% endblock %}
 
 {% block keyboardinput %}
-<div role="button" aria-label="Use Keyboard Input to make annotations. To make an annotation, click the 'Make an Annotation' button. You will be taken to back to the content where you can add an asterisk (*) to the beginning and an asterisk(*) to the end of the area you would like to select. Make sure not to edit any other parts of the text! Then hit the 'Save Highlights' button." class="fa fa-keyboard-o" title="Make annotations using keyboard input" id="keyboard-input-toggle-text"></div>
+<div role="button" aria-label="Use Keyboard Input to make annotations. To make an annotation, click the 'Make an Annotation' button. You will be taken to back to the content where you can add an asterisk (*) to the beginning and an asterisk(*) to the end of the area you would like to select. Make sure not to edit any other parts of the text! Then hit the 'Save Highlights' button." class="fa fa-keyboard-o clicking_allowed" title="Make annotations using keyboard input" id="keyboard-input-toggle-text" tabindex="0"></div>
 {% endblock %}
 
 {% block mainapplication %}

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -71,7 +71,6 @@ Annotation Tool | Text | {{ target_object.target_title }}
           </div>
           <button role="button" class="btn btn-default" data-toggled="false">Save Highlights</button>
       </section>
-   <div class="annotations-status on" role="button" aria-label="Toggle Annotations over content"><i class="fa fa-close"></i> <span role="tooltip" id="annotations-status-label" class="hover-inst hidden">Hide Annotations</span></div>
         <div class="btn-toolbar target-object-controls" role="toolbar" aria-label="Annotation toolbar controls">
             <div class="btn-group" role="group" aria-label="Hide or Show Annotations">
                 <button id="annotations-status" type="button" class="btn btn-default on" aria-label="Hide Annotations">

--- a/hx_lti_initializer/templates/vd/detail.html
+++ b/hx_lti_initializer/templates/vd/detail.html
@@ -62,6 +62,10 @@ Annotation Tool | Video | {{ target_object.target_title }}
 
 {% block mainapplication %}
 <section role="main" aria-label="Annotation Tool Video Content" style="height: 100%">
+  <h3 class='offscreen'>Video to be Annotated</h3>
+  <div id="text-content-notifications" aria-live="assertive"></div>
+  <div id="hxat-status" role="alert"></div>
+  <div id="hxat-alert" role="alert"></div>
 	<div  id="viewer" class="test" style="padding-top:50px; height:80%;" class="fit-to-canvas">
 		<video id="vid1" class="video-js vjs-default-skin" controls preload="none" width="auto" height="100%" style="height:80%;">
       {{ target_object.get_target_content_for_video | safe }}

--- a/hx_lti_initializer/templates/vd/detail.html
+++ b/hx_lti_initializer/templates/vd/detail.html
@@ -61,7 +61,7 @@ Annotation Tool | Video | {{ target_object.target_title }}
 {% endblock %}
 
 {% block mainapplication %}
-<section role="application" aria-label="Annotation Tool Video Content" style="height: 100%">
+<section role="main" aria-label="Annotation Tool Video Content" style="height: 100%">
 	<div  id="viewer" class="test" style="padding-top:50px; height:80%;" class="fit-to-canvas">
 		<video id="vid1" class="video-js vjs-default-skin" controls preload="none" width="auto" height="100%" style="height:80%;">
       {{ target_object.get_target_content_for_video | safe }}


### PR DESCRIPTION
These accessibility fixes contain a lot of changes gathered from the feedback of live testers using various assistive technologies (JAWS, VoiceOver, TextZoom, etc.) and tries to provide a more detail flow and feedback through making annotations. 

The various fixes include the following:

1. Adding tabindex attributes to make sure that keyboard users do not miss them
2. Providing more appropriate header names for the different sections of the tool
3. Added some more detailed labels for Mirador and videojs
4. Added a lot of alerts to provide feedback when user does something, e.g. "Sidebar is now hidden" or "Annotation was just created"
5. Met some edX accessibility guidelines (they reserve h1 and h2 tags for their platform and LTI components should start with h3)

This includes fixes found in PR #87 , PR #88 , PR #89 but the base now includes the latest merge from @arthurian . Those PRs will now be marked as closed. 