### PR TITLE
jquery confirm needs call to be asynchronous to close

### DIFF
--- a/hx_lti_initializer/static/DashboardView.js
+++ b/hx_lti_initializer/static/DashboardView.js
@@ -798,8 +798,10 @@
             placement: 'left',
             onConfirm: function (){
                 if(annotationItem.authToDeleteButton) {
-                    self.initOptions.endpoint.deleteAnnotation(annotation);
-                    jQuery('#hxat-alert').html('Annotation has been deleted');
+                    setTimeout(function() {
+                        self.initOptions.endpoint.deleteAnnotation(annotation);
+                        jQuery('#hxat-alert').html('Annotation has been deleted');
+                    }, 1);
                 }
             },
         });


### PR DESCRIPTION
Previously the confirm popup was not housed in body (so it was partially hidden), but in the modal annotation view. Once deletion happened that modal view was deleted and so was the popup. By moving this to body, it was now not being deleted since there was an ajax call (to delete) being run synchronously. 