### PR TITLE
more straighforward way to read DEBUG env var as boolean

### DIFF
--- a/annotationsx/settings/base.py
+++ b/annotationsx/settings/base.py
@@ -23,7 +23,16 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', SECURE_SETTINGS.get('django_secret_key', ''))
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = literal_eval(os.environ.get('DEBUG', str(SECURE_SETTINGS.get('debug', True))))
+
+# disambiguation when reading from env: env vars always strings so if
+# DEBUG=False, it's still evaluated as boolean True. Some ways to read a
+# boolean from a string source in this related thread:
+#   https://stackoverflow.com/questions/21732123/convert-true-false-value-read-from-file-to-boolean
+debug = os.environ.get('DEBUG', None)
+if debug is None:
+    DEBUG = SECURE_SETTINGS.get('debug', False)
+else:
+    DEBUG = debug.lower() == 'true'
 
 ALLOWED_HOSTS = ['localhost',  '127.0.0.1']
 other_hosts = os.environ.get('ALLOWED_HOSTS', None)

--- a/annotationsx/settings/prod.py
+++ b/annotationsx/settings/prod.py
@@ -5,7 +5,6 @@ from .aws import *
 # remove log file to avoid crowding the disk: hx provision does not configure
 # rotation nor cleanup for app log files!
 #
-DEBUG = False
 LOGGING['loggers']['django']['handlers'] = ['console']
 LOGGING['loggers']['django.request']['handlers'] = ['console']
 LOGGING['loggers']['django.db.backends']['handlers'] = ['console']


### PR DESCRIPTION
- whatever value that is not 'true'.lower() is considered False
  AND if not defined as env var, pulls from secure.py.

- also removed DEBUG=False from settings.prod so it is possible
  to set DEBUG=True in production via env var