### PR TITLE
Temporary fix

### DIFF
--- a/hx_lti_initializer/templates/ig/detail.html
+++ b/hx_lti_initializer/templates/ig/detail.html
@@ -108,7 +108,7 @@ var mir = Mirador({
     "options": {
       token: "{{ token }}",
       // The endpoint of the store on your server.
-			prefix: "{% url 'annotation_store:api_root' %}",
+			prefix: "{% url 'annotation_store:api_root' %}".replace('api/','api'),
       {% if utm_source %}
       params: "?utm_source={{ utm_source }}&resource_link_id={{ resource_link_id }}",
       {% else %}


### PR DESCRIPTION
This will be removed when Hxighlighter becomes the norm.

the api_root url differs between image and text now. texts expects it to end with '/' but image breaks if that happens.

Janky fix...but quick and will be deprecated once hxighlighter expands to include Mirador.