### PR TITLE
2019 10 28 hrange fixes

### DIFF
--- a/hx_lti_initializer/static/Hxighlighter/hxighlighter_text.js
+++ b/hx_lti_initializer/static/Hxighlighter/hxighlighter_text.js
@@ -1,4 +1,4 @@
-// [AIV_SHORT]  Version: 1.0.0 - Monday, October 28th, 2019, 12:58:01 PM  
+// [AIV_SHORT]  Version: 1.0.0 - Monday, October 28th, 2019, 4:50:36 PM  
  /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -28135,7 +28135,8 @@ function compareExactText(text1, text2) {
 
   var res1 = getDiff(text1, text2);
   var res2 = getDiff(text2, text1);
-  return text1 === text2 || res1.trim().length === 0 || res2.trim().length === 0;
+  var regexp = /[^A-Za-z0-9]+/g;
+  return text1 === text2 || res1.trim().length === 0 || res2.trim().length === 0 || regexp.test(res1) || regexp.test(res2);
 }
 
 ;
@@ -28314,21 +28315,6 @@ function getIndicesOf(searchStr, str, caseSensitive) {
   }
 
   return indices;
-} // https://stackoverflow.com/questions/29573700/finding-the-difference-between-two-string-in-javascript-with-regex
-
-
-function isDifferenceAlphaNumeric(a, b) {
-  var i = 0;
-  var j = 0;
-  var result = "";
-
-  while (j < b.length) {
-    if (a[i] != b[j] || i == a.length) result += b[j];else i++;
-    j++;
-  }
-
-  var regex = /^[A-Za-z0-9]+$/i;
-  return regex.test(result);
 }
 
 function normalizeRange(serializedRange, root, ignoreSelector) {
@@ -28342,18 +28328,17 @@ function normalizeRange(serializedRange, root, ignoreSelector) {
   var _start = sR.start;
   var _end = sR.end;
   var _startOffset = sR.startOffset;
-  var _endOffset = sR.endOffset; // three ways of getting text:
+  var _endOffset = sR.endOffset;
+  var normalizedRange = document.createRange(); // three ways of getting text:
   // Way #1: Given an xpath, find the way to the node
 
   var startResult = getNodeFromXpath(root, _start, _startOffset, ignoreSelector);
   var endResult = getNodeFromXpath(root, _end, _endOffset, ignoreSelector);
 
   if (startResult && endResult) {
-    var normalizedRange = document.createRange();
     normalizedRange.setStart(startResult.node, startResult.offset);
     normalizedRange.setEnd(endResult.node, endResult.offset); //console.log('HERE', _start, _startOffset, _end, _endOffset, startResult, endResult, getExactText(normalizedRange), serializedRange.text.exact);
-
-    console.log("Xpath Test: ", getExactText(normalizedRange), serializedRange.text.exact, compareExactText(getExactText(normalizedRange), serializedRange.text.exact) ? "YES THEY MATCH" : "NO THEY DO NOT MATCH");
+    //console.log("Xpath Test: ", getExactText(normalizedRange), serializedRange.text.exact, compareExactText(getExactText(normalizedRange), serializedRange.text.exact) ? "YES THEY MATCH" : "NO THEY DO NOT MATCH")
   } //console.log(_start, _startOffset, startResult, endResult);
   //console.log(getPrefixAndSuffix(normalizedRange, root, ignoreSelector))
   // Way #2: if that doesn't match what we have stored as the quote, try global positioning from root
@@ -28389,7 +28374,7 @@ function normalizeRange(serializedRange, root, ignoreSelector) {
         break;
       }
     }
-  } // Possible Way #5: fuzzy search? TBD, no idea how to do this. fuzzy substrings are not as common as searching list of records
+  } // Possible Way #4: fuzzy search? TBD, no idea how to do this. fuzzy substrings are not as common as searching list of records
 
 
   return normalizedRange;
@@ -28517,13 +28502,19 @@ function recurseFromNodeToNode(currentNode, range) {
 
 function getTextNodesFromAnnotationRanges(ranges, root) {
   var textNodesList = [];
-  ranges.forEach(function (range) {
-    var normRanged = normalizeRange(range, root, 'annotator-hl'); //recurseFromNodeToNode(range.startContainer, range);
 
-    var nodes = recurseFromNodeToNode(normRanged.startContainer, normRanged); //console.log(normRanged, ranges, nodes, normRanged.cloneContents());
+  try {
+    ranges.forEach(function (range) {
+      var normRanged = normalizeRange(range, root, 'annotator-hl'); //recurseFromNodeToNode(range.startContainer, range);
 
-    textNodesList = textNodesList.concat(nodes.nodes);
-  });
+      var nodes = recurseFromNodeToNode(normRanged.startContainer, normRanged); //console.log(normRanged, ranges, nodes, normRanged.cloneContents());
+
+      textNodesList = textNodesList.concat(nodes.nodes);
+    });
+  } catch (e) {
+    console.log("There was an error in getting the ranges.");
+  }
+
   return textNodesList;
 }
 
@@ -45267,7 +45258,6 @@ var hrange = __webpack_require__(3);
           });
         }
       } else if (xpathRanges.length === 1 && positionRanges.length === 0 && textRanges.length === 0) {
-        console.log(element, xpathRanges);
         var startNode = hrange.getNodeFromXpath(element, xpathRanges[0].start, xpathRanges[0].startOffset, 'annotator-hl');
         var endNode = hrange.getNodeFromXpath(element, xpathRanges[0].end, xpathRanges[0].endOffset, 'annotator-hl');
 

--- a/hx_lti_initializer/static/Hxighlighter/hxighlighter_text.js
+++ b/hx_lti_initializer/static/Hxighlighter/hxighlighter_text.js
@@ -1,4 +1,4 @@
-// [AIV_SHORT]  Version: 1.0.0 - Thursday, September 12th, 2019, 4:57:18 PM  
+// [AIV_SHORT]  Version: 1.0.0 - Monday, October 28th, 2019, 12:58:01 PM  
  /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -28253,6 +28253,11 @@ function getNodeFromXpath(root, xpath, offset, ignoreSelector) {
     return it.length > 0;
   });
   var traversingDown = root;
+
+  if (!(traversingDown instanceof HTMLElement) && typeof traversingDown[0] !== "undefined") {
+    traversingDown = traversingDown[0];
+  }
+
   tree.forEach(function (it) {
     var selector = it.replace(/\[.*\]/g, '');
     var counter = parseInt(it.replace(/.*?\[(.*)\]/g, '$1'), 10) - 1;
@@ -28309,6 +28314,21 @@ function getIndicesOf(searchStr, str, caseSensitive) {
   }
 
   return indices;
+} // https://stackoverflow.com/questions/29573700/finding-the-difference-between-two-string-in-javascript-with-regex
+
+
+function isDifferenceAlphaNumeric(a, b) {
+  var i = 0;
+  var j = 0;
+  var result = "";
+
+  while (j < b.length) {
+    if (a[i] != b[j] || i == a.length) result += b[j];else i++;
+    j++;
+  }
+
+  var regex = /^[A-Za-z0-9]+$/i;
+  return regex.test(result);
 }
 
 function normalizeRange(serializedRange, root, ignoreSelector) {
@@ -28332,14 +28352,15 @@ function normalizeRange(serializedRange, root, ignoreSelector) {
     var normalizedRange = document.createRange();
     normalizedRange.setStart(startResult.node, startResult.offset);
     normalizedRange.setEnd(endResult.node, endResult.offset); //console.log('HERE', _start, _startOffset, _end, _endOffset, startResult, endResult, getExactText(normalizedRange), serializedRange.text.exact);
-    //console.log("Xpath Test: ", compareExactText(getExactText(normalizedRange), serializedRange.text.exact) ? "YES THEY MATCH" : "NO THEY DO NOT MATCH")
+
+    console.log("Xpath Test: ", getExactText(normalizedRange), serializedRange.text.exact, compareExactText(getExactText(normalizedRange), serializedRange.text.exact) ? "YES THEY MATCH" : "NO THEY DO NOT MATCH");
   } //console.log(_start, _startOffset, startResult, endResult);
   //console.log(getPrefixAndSuffix(normalizedRange, root, ignoreSelector))
   // Way #2: if that doesn't match what we have stored as the quote, try global positioning from root
   // This is for the usecase where someone has changed tagnames so xpath cannot be found
 
 
-  if (!(startResult && endResult) || serializedRange.text.exact && !compareExactText(getExactText(normalizedRange), serializedRange.text.exact)) {
+  if (!(startResult && endResult) || serializedRange.text.exact && typeof serializedRange.position !== "undefined" && !compareExactText(getExactText(normalizedRange), serializedRange.text.exact)) {
     startResult = recurseGetNodeFromOffset(root, serializedRange.position.globalStartOffset); //getNodeFromXpath(root, '/', serializedRange.position.globalStartOffset, ignoreSelector);
 
     endResult = recurseGetNodeFromOffset(root, serializedRange.position.globalEndOffset); //getNodeFromXpath(root, '/', serializedRange.position.globalEndOffset, ignoreSelector);
@@ -28368,7 +28389,7 @@ function normalizeRange(serializedRange, root, ignoreSelector) {
         break;
       }
     }
-  } // Possible Way #4: fuzzy search? TBD, no idea how to do this. fuzzy substrings are not as common as searching list of records
+  } // Possible Way #5: fuzzy search? TBD, no idea how to do this. fuzzy substrings are not as common as searching list of records
 
 
   return normalizedRange;
@@ -45246,6 +45267,7 @@ var hrange = __webpack_require__(3);
           });
         }
       } else if (xpathRanges.length === 1 && positionRanges.length === 0 && textRanges.length === 0) {
+        console.log(element, xpathRanges);
         var startNode = hrange.getNodeFromXpath(element, xpathRanges[0].start, xpathRanges[0].startOffset, 'annotator-hl');
         var endNode = hrange.getNodeFromXpath(element, xpathRanges[0].end, xpathRanges[0].endOffset, 'annotator-hl');
 
@@ -45583,8 +45605,6 @@ __webpack_require__(70);
     if (self.options.PrevNextButton) {
       self.prevUrl = self.options.PrevNextButton.prevUrl;
       self.nextUrl = self.options.PrevNextButton.nextUrl;
-      self.current = self.options.PrevNextButton.current;
-      self.total = self.options.PrevNextButton.total;
       self.setUpButtons();
     }
   };
@@ -45595,17 +45615,13 @@ __webpack_require__(70);
     var toPrepend = "";
 
     if (self.prevUrl && self.prevUrl != "") {
-      toPrepend += '<a href="' + self.prevUrl + '" title="Back" id="prevButtonTop" role="button">Back</a>';
-      toAppend += '<a href="' + self.prevUrl + '" title="Back" id="prevButtonBottom" role="button">Back</a>'; //jQuery(self.options.slot).append('<a href="'+self.prevUrl+'" title="Previous Page" id="prevButton" role="button">Previous</button>');
-    }
-
-    if (self.current && self.total && self.total !== 1) {
-      toPrepend += "<span class='counter'>" + self.current + " out of " + self.total + "</span>";
+      toPrepend += '<a href="' + self.prevUrl + '" title="Previous Page" id="prevButtonTop" role="button">Previous</button>';
+      toAppend += '<a href="' + self.prevUrl + '" title="Previous Page" id="prevButtonBottom" role="button">Previous</button>'; //jQuery(self.options.slot).append('<a href="'+self.prevUrl+'" title="Previous Page" id="prevButton" role="button">Previous</button>');
     }
 
     if (self.nextUrl && self.nextUrl != "") {
-      toPrepend += '<a href="' + self.nextUrl + '" title="Continue" id="nextButtonTop" role="button">Continue</a>';
-      toAppend += '<a href="' + self.nextUrl + '" title="Continue" id="nextButtonBottom" role="button">Continue</as>'; //jQuery(self.options.slot).append('<a href="'+self.nextUrl+'" title="Next Page" id="nextButton" role="button">Next</button>');
+      toPrepend += '<a href="' + self.nextUrl + '" title="Next Page" id="nextButtonTop" role="button">Next</button>';
+      toAppend += '<a href="' + self.nextUrl + '" title="Next Page" id="nextButtonBottom" role="button">Next</button>'; //jQuery(self.options.slot).append('<a href="'+self.nextUrl+'" title="Next Page" id="nextButton" role="button">Next</button>');
     }
 
     jQuery(self.options.slot).before(toPrepend);

--- a/hx_lti_initializer/static/Hxighlighter/hxighlighter_text.js
+++ b/hx_lti_initializer/static/Hxighlighter/hxighlighter_text.js
@@ -1,4 +1,4 @@
-// [AIV_SHORT]  Version: 1.0.0 - Monday, October 28th, 2019, 4:50:36 PM  
+// [AIV_SHORT]  Version: 1.0.0 - Monday, October 28th, 2019, 5:34:21 PM  
  /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -123,6 +123,7 @@
 					jQuery('label[for="id_target_content"]').text('Source Content');
 					if ("{{ form.target_content.value | escapejs }}".length > 0) {
 						console.log("Should disable", "{{ form.target_content.value | escapejs }}");
+						console.log(jQuery('#id_target_content').summernote('isEmpty'));
 						jQuery('#id_target_content').summernote('disable');
 					}
 

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -34,14 +34,14 @@
 		$('select[name=target_courses]').val(courseValue);
 		$('.selectpicker').selectpicker('refresh');
 
+		{% if form.target_type == 'vd' %}
 		var links = "{{form.target_content.value | escapejs}}".split(';');
-		console.log('find me', links);
 		if (links.length === 3) {
 			window.youtubeLink = links[0] || "";
 			window.html5Link = links[1] || "";
 			window.transcript_link = links[2] || "";
 		}
-
+		{% endif %}
 		// window.youtubeLink = "{{form.target_content.value | just_the_youtube_vid_link:form.target_type | escapejs}}";
 		// window.html5Link = "{{form.target_content.value | just_the_html5_vid_link:form.target_type | escapejs}}";
 		// window.transcript_link = "{{form.target_content.value | just_the_transcript_link:form.target_type | escapejs}}";
@@ -209,6 +209,13 @@
 
 			<div class="help_text">Do not deselect any courses, just make sure yours is selected</div>
 		</div>
+		{% if form.target_type == "tx" and form.target_content.value !== "" %}
+			<script>
+				jQuery(document).ready(function() {
+					jQuery('#id_target_content').summernote("disable");
+				});
+			</script>
+		{% endif %}
 
 		{% buttons %}
 			<div type="submit" class="save" id='source-save-button'>

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -122,9 +122,14 @@
 					jQuery('#id_target_content').summernote(options);
 					jQuery('label[for="id_target_content"]').text('Source Content');
 					if ("{{ form.target_content.value | escapejs }}".length > 0) {
-						console.log("Should disable", "{{ form.target_content.value | escapejs }}");
-						console.log(jQuery('#id_target_content').summernote('isEmpty'));
-						jQuery('#id_target_content').summernote('disable');
+						jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", false);
+						var warn_user = function() {
+							var result = confirm('Editing Text (even a small typo or formatting) may cause you to lose annotations anyone has created. Talk to Tech Team to get full details on the effects of your changes.\n Do you want to still edit text?');
+							if (result) {
+								jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", true);
+							}
+						}
+						jQuery('#id_target_content').next().find
 					}
 
 				} else if (value === "ig") {

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -124,8 +124,8 @@
 					jQuery('.tx').show();
 					jQuery('#id_target_content').summernote(options);
 					jQuery('label[for="id_target_content"]').text('Source Content');
-					jQuery('#id_target_content').before('<p class="tx" style="font-size: 0.75em">Warning: Make sure to do all copy edits before making any annotations. Making changes to the text after any annotations have been made may cause you to have to remake the annotations as well.</p>')
-					if ("{{ form.target_content.value | escapejs }}".length > 0) {
+					jQuery('#id_target_content').before('<p class="tx" style="font-size: 0.75em">Warning: Make sure to do all copy edits before making any annotations. Making changes to the text after any annotations have been made may cause you to have to remake the annotations as well.</p>');
+					if ("{{ form.target_content.value | escapejs }}".length > 0 || "{{ form.target_content.value | escapejs }}" === "None") {
 						jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", false);
 						var warn_user = function() {
 							var result = confirm('Editing text (even a small typo or formatting) may cause you to lose annotations anyone has created.\nTalk to Tech Team to get full details on the effects of your changes.\n\nDo you want to still edit text?');

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -127,7 +127,7 @@
 							var result = confirm('Editing Text (even a small typo or formatting) may cause you to lose annotations anyone has created. Talk to Tech Team to get full details on the effects of your changes.\n Do you want to still edit text?');
 							if (result) {
 								jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", true);
-								Query('#id_target_content').next().find('.note-editable').off('click', warn_user);
+								jQuery('#id_target_content').next().find('.note-editable').off('click', warn_user);
 							}
 
 						}

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -126,6 +126,7 @@
 					jQuery('label[for="id_target_content"]').text('Source Content');
 					jQuery('#id_target_content').before('<p class="tx" style="font-size: 0.75em">Warning: Make sure to do all copy edits before making any annotations. Making changes to the text after any annotations have been made may cause you to have to remake the annotations as well.</p>');
 					if ("{{ form.target_content.value | escapejs }}".length > 0 || "{{ form.target_content.value | escapejs }}" === "None") {
+						console.log("Content: ", "{{ form.target_content.value | escapejs }}", "{{ form.target_content.value | escapejs }}".length);
 						jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", false);
 						var warn_user = function() {
 							var result = confirm('Editing text (even a small typo or formatting) may cause you to lose annotations anyone has created.\nTalk to Tech Team to get full details on the effects of your changes.\n\nDo you want to still edit text?');

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -121,6 +121,7 @@
 					jQuery('.tx').show();
 					jQuery('#id_target_content').summernote(options);
 					jQuery('label[for="id_target_content"]').text('Source Content');
+					jQuery('#id_target_content').before('<p class="tx" style="font-size: 0.75em">Warning: Make sure to do all copy edits before making any annotations. Making changes to the text after any annotations have been made may cause you to have to remake the annotations as well.</p>')
 					if ("{{ form.target_content.value | escapejs }}".length > 0) {
 						jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", false);
 						var warn_user = function() {

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -72,15 +72,15 @@
 	var createVideoFields = function() {
 		jQuery('.vdchange').before("<div class='form-group vd'>\
 			<label for=\"id_youtube_vid_link\">Youtube Video Link:</label>\
-			<input id=\"id_youtube_vid_link\" maxlength=\"255\" name=\"youtube_vid_link\" class=\"form-control video_option hx-textfield\" type=\"text\" value=\""+window.youtubeLink+"\">\
+			<input id=\"id_youtube_vid_link\" maxlength=\"255\" name=\"youtube_vid_link\" class=\"form-control video_option hx-textfield\" type=\"text\" value=\""+(window.youtubeLink || "")+"\">\
 			<div class=\"help_text\">If you don't include an HTML5-approved video (e.g. .mp4), you must include a youtube video.</div>\
 			</div><div class='form-group vd'>\
 			<label for=\"id_html5_vid_link\">HTML5 Video Link:</label>\
-			<input id=\"id_html5_vid_link\" maxlength=\"255\" name=\"html5_vid_link\" class=\"form-control video_option hx-textfield\" type=\"text\" value=\""+window.html5Link+"\">\
+			<input id=\"id_html5_vid_link\" maxlength=\"255\" name=\"html5_vid_link\" class=\"form-control video_option hx-textfield\" type=\"text\" value=\""+ (window.html5Link || "")+"\">\
 			<div class=\"help_text\">If you don't include a Youtube video (e.g. .mp4), you must include an HTML5-approved video.</div>\
 			</div><div class='form-group vd'>\
 			<label for=\"id_transcript_link\">Transcript Link:</label>\
-			<input id=\"id_transcript_link\" maxlength=\"255\" name=\"transcript_link\" class=\"form-control video_option hx-textfield\" type=\"text\" value=\""+window.transcript_link+"\">\
+			<input id=\"id_transcript_link\" maxlength=\"255\" name=\"transcript_link\" class=\"form-control video_option hx-textfield\" type=\"text\" value=\""+(window.transcript_link || "")+"\">\
 			</div>");
 		jQuery('.video_option').change(function (e){
         	var youtube_vid_link = jQuery('#id_youtube_vid_link').val();
@@ -126,7 +126,6 @@
 					jQuery('label[for="id_target_content"]').text('Source Content');
 					jQuery('#id_target_content').before('<p class="tx" style="font-size: 0.75em">Warning: Make sure to do all copy edits before making any annotations. Making changes to the text after any annotations have been made may cause you to have to remake the annotations as well.</p>');
 					if ("{{ form.target_content.value | escapejs }}".length > 4 || "{{ form.target_content.value | escapejs }}" !== "None") {
-						console.log("Content: ", "{{ form.target_content.value | escapejs }}", "{{ form.target_content.value | escapejs }}".length);
 						jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", false);
 						var warn_user = function() {
 							var result = confirm('Editing text (even a small typo or formatting) may cause you to lose annotations anyone has created.\nTalk to Tech Team to get full details on the effects of your changes.\n\nDo you want to still edit text?');

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -124,7 +124,7 @@
 					if ("{{ form.target_content.value | escapejs }}".length > 0) {
 						jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", false);
 						var warn_user = function() {
-							var result = confirm('Editing Text (even a small typo or formatting) may cause you to lose annotations anyone has created. Talk to Tech Team to get full details on the effects of your changes.\n Do you want to still edit text?');
+							var result = confirm('Editing text (even a small typo or formatting) may cause you to lose annotations anyone has created.\nTalk to Tech Team to get full details on the effects of your changes.\n\nDo you want to still edit text?');
 							if (result) {
 								jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", true);
 								jQuery('#id_target_content').next().find('.note-editable').off('click', warn_user);

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -125,7 +125,7 @@
 					jQuery('#id_target_content').summernote(options);
 					jQuery('label[for="id_target_content"]').text('Source Content');
 					jQuery('#id_target_content').before('<p class="tx" style="font-size: 0.75em">Warning: Make sure to do all copy edits before making any annotations. Making changes to the text after any annotations have been made may cause you to have to remake the annotations as well.</p>');
-					if ("{{ form.target_content.value | escapejs }}".length > 0 || "{{ form.target_content.value | escapejs }}" === "None") {
+					if ("{{ form.target_content.value | escapejs }}".length > 4 || "{{ form.target_content.value | escapejs }}" !== "None") {
 						console.log("Content: ", "{{ form.target_content.value | escapejs }}", "{{ form.target_content.value | escapejs }}".length);
 						jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", false);
 						var warn_user = function() {

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -37,9 +37,9 @@
 		var links = "{{form.target_content.value | escapejs}}".split(';');
 		console.log('find me', links);
 		if (links.length === 3) {
-			window.youtubeLink = links[0];
-			window.html5Link = links[1];
-			window.html5Link = links[2];
+			window.youtubeLink = links[0] || "";
+			window.html5Link = links[1] || "";
+			window.transcript_link = links[2] || "";
 		}
 
 		// window.youtubeLink = "{{form.target_content.value | just_the_youtube_vid_link:form.target_type | escapejs}}";

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -34,9 +34,17 @@
 		$('select[name=target_courses]').val(courseValue);
 		$('.selectpicker').selectpicker('refresh');
 
-		window.youtubeLink = "{{form.target_content.value | just_the_youtube_vid_link:form.target_type | escapejs}}";
-		window.html5Link = "{{form.target_content.value | just_the_html5_vid_link:form.target_type | escapejs}}";
-		window.transcript_link = "{{form.target_content.value | just_the_transcript_link:form.target_type | escapejs}}";
+		var links = "{{form.target_content.value | escapejs}}".split(';');
+		console.log('find me', links);
+		if (links.length === 3) {
+			window.youtubeLink = links[0];
+			window.html5Link = links[1];
+			window.html5Link = links[2];
+		}
+
+		// window.youtubeLink = "{{form.target_content.value | just_the_youtube_vid_link:form.target_type | escapejs}}";
+		// window.html5Link = "{{form.target_content.value | just_the_html5_vid_link:form.target_type | escapejs}}";
+		// window.transcript_link = "{{form.target_content.value | just_the_transcript_link:form.target_type | escapejs}}";
 
 		{% if form.target_type == 'ig' and form.target_content.value != None and form.target_content.value != "None" %}
 		var jqxhr = $.ajax( "{{ form.target_content.value|escapejs }}")

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -36,6 +36,9 @@
 
 		{% if form.target_type == 'vd' %}
 		var links = "{{form.target_content.value | escapejs}}".split(';');
+		window.youtubeLink =  "";
+		window.html5Link = "";
+		window.transcript_link = "";
 		if (links.length === 3) {
 			window.youtubeLink = links[0] || "";
 			window.html5Link = links[1] || "";

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -127,9 +127,11 @@
 							var result = confirm('Editing Text (even a small typo or formatting) may cause you to lose annotations anyone has created. Talk to Tech Team to get full details on the effects of your changes.\n Do you want to still edit text?');
 							if (result) {
 								jQuery('#id_target_content').next().find(".note-editable").attr("contenteditable", true);
+								Query('#id_target_content').next().find('.note-editable').off('click', warn_user);
 							}
+
 						}
-						jQuery('#id_target_content').next().find
+						jQuery('#id_target_content').next().find('.note-editable').on('click', warn_user);
 					}
 
 				} else if (value === "ig") {

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -209,7 +209,7 @@
 
 			<div class="help_text">Do not deselect any courses, just make sure yours is selected</div>
 		</div>
-		{% if form.target_type == "tx" and form.target_content.value !== "" %}
+		{% if form.target_type == "tx" and form.target_content.value != "" %}
 			<script>
 				jQuery(document).ready(function() {
 					jQuery('#id_target_content').summernote("disable");

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -121,6 +121,11 @@
 					jQuery('.tx').show();
 					jQuery('#id_target_content').summernote(options);
 					jQuery('label[for="id_target_content"]').text('Source Content');
+					if ("{{ form.target_content.value | escapejs }}".length > 0) {
+						console.log("Should disable", "{{ form.target_content.value | escapejs }}");
+						jQuery('#id_target_content').summernote('disable');
+					}
+
 				} else if (value === "ig") {
 					jQuery('.vd').hide();
 					jQuery('.tx').hide();
@@ -209,13 +214,6 @@
 
 			<div class="help_text">Do not deselect any courses, just make sure yours is selected</div>
 		</div>
-		{% if form.target_type == "tx" and form.target_content.value != "" %}
-			<script>
-				jQuery(document).ready(function() {
-					jQuery('#id_target_content').summernote("disable");
-				});
-			</script>
-		{% endif %}
 
 		{% buttons %}
 			<div type="submit" class="save" id='source-save-button'>


### PR DESCRIPTION
1. Updated Hxighlighter's h-range file to forego checking global position if the variable does not exist (as it does not for annotations created before switch to WebAnnotations).
2. Added check to see if in cases where the xpath matches, but the text does not, that nonalphanumeric differences (such as extra spaces or carriage returns) are accepted as still matching.
3. Added some padding to the lower end of the previous-next button
4. Added message when editing text target objects to warn authors of the implications to any annotations that may have been made beforehand. It also disables to text and requires manual override to edit.
5. Added fix to show the proper values for video links.