### PR TITLE
lti auth

### DIFF
--- a/annotationsx/middleware.py
+++ b/annotationsx/middleware.py
@@ -17,6 +17,7 @@ import collections
 from django.conf import settings
 from django.core.exceptions import PermissionDenied, ImproperlyConfigured
 from django.http import HttpResponse
+from django.http import HttpResponseBadRequest
 from lti.contrib.django import DjangoToolProvider
 import logging
 import time
@@ -45,7 +46,7 @@ def ip_address(request):
 class LTILaunchError(Exception):
     pass
 
-class LTILaunchSession(MiddlewareMixin):
+class LTILaunchSession(object):
     '''
     Dict-like object that provides access to the session dict containing for the LTI Launch,
     which is keyed by the resource_link_id.
@@ -69,6 +70,10 @@ class LTILaunchSession(MiddlewareMixin):
 
     def assert_valid(self):
         '''Raises an exception if a valid launch session is not present, usually because the resource_link_id is not provided.'''
+
+        # 03feb20 naomi: these exceptions are raised in the view, when
+        # manipulating the session in request.LTI; so it will be handled by the
+        # process_exception()
         if not self.resource_link_id:
             raise LTILaunchError("Invalid LTI session: resource_link_id is not present")
         elif 'LTI_LAUNCH' not in self.session:
@@ -135,7 +140,7 @@ class ContentSecurityPolicyMiddleware(MiddlewareMixin):
                 response['Content-Security-Policy'] = policy
                 self.logger.info('Content-Security-Policy header set to: %s' % policy)
             else:
-                self.logger.warn('Content-Security-Policy header not set')
+                self.logger.warning('Content-Security-Policy header not set')
         return response
 
 class CookielessSessionMiddleware(MiddlewareMixin):
@@ -208,18 +213,37 @@ class MultiLTILaunchMiddleware(MiddlewareMixin):
             self.logger.error(exception)
             return HttpResponse("LTI launch error. Please try re-launching the tool.")
         return None
+        # when moving to django2 and replacing MIDDLEWARE_CLASSES to MIDDLEWARE in
+        # settings, the behavior of exceptions in middleware changed:
+        # https://docs.djangoproject.com/en/2.2/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+        # "Under MIDDLEWARE_CLASSES, process_exception is applied to exceptions raised from a middleware 
+        # process_request method. Under MIDDLEWARE, process_exception applies only
+        # to exceptions raised from the view."
+        #
+        # so, middleware classes cannot rely on exceptions to short-circuit the
+        # request life-cycle in django anymore!
 
     def process_request(self, request):
         self.logger.info("Inside %s process_request: %s" % (self.__class__.__name__, request.path))
         is_basic_lti_launch = (request.method == 'POST' and request.POST.get('lti_message_type') == 'basic-lti-launch-request')
         self.logger.info("basic-lti-launch-request? %s" % is_basic_lti_launch)
         if is_basic_lti_launch:
-            self._validate_request(request)
-            self._update_session(request)
-            self._log_ip_address(request)
-            self._set_current_session(request, resource_link_id=request.POST.get('resource_link_id'), raise_exception=True)
+            try:
+                self._validate_request(request)
+                self._update_session(request)
+                self._log_ip_address(request)
+                self._set_current_session(
+                        request,
+                        resource_link_id=request.POST.get('resource_link_id'))
+            except LTILaunchError:
+                return HttpResponseBadRequest()
+            except Exception:
+                raise
         else:
-            self._set_current_session(request, resource_link_id=request.GET.get('resource_link_id'), raise_exception=False)
+            self._set_current_session(
+                    request,
+                    resource_link_id=request.GET.get('resource_link_id'))
+
         return self.get_response(request)
 
     def _validate_request(self, request):
@@ -234,16 +258,16 @@ class MultiLTILaunchMiddleware(MiddlewareMixin):
 
         if consumer_key is None or secret is None:
             self.logger.error("missing consumer key/secret: %s/%s" % (consumer_key, secret))
-            raise ImproperlyConfigured("Unable to validate LTI launch. Missing setting: CONSUMER_KEY or LTI_SECRET")
+            raise PermissionDenied
 
         request_key = request.POST.get('oauth_consumer_key', None)
         if request_key is None:
             self.logger.error("request doesn't contain an oauth_consumer_key; can't continue.")
-            raise LTILaunchError
+            raise PermissionDenied
 
         if request_key != consumer_key:
             self.logger.error("could not get a secret for requested key: %s" % request_key)
-            raise LTILaunchError
+            raise PermissionDenied
 
         self.logger.debug('using key/secret %s/%s' % (request_key, secret))
         tool_provider = DjangoToolProvider.from_django_request(
@@ -259,34 +283,32 @@ class MultiLTILaunchMiddleware(MiddlewareMixin):
             self.logger.debug('META %s: %s' % (key, request.META.get(key)))
 
         self.logger.debug("about to check the signature")
-        try:
-            # NOTE: before validating the request, temporarily remove the
-            # QUERY_STRING to work around an issue with how Canvas signs requests
-            # that contain GET parameters. Before Canvas launches the tool, it duplicates the GET
-            # parameters as POST parameters, and signs the POST parameters (*not* the GET parameters).
-            # However, the oauth2 library that validates the request generates
-            # the oauth signature based on the combination of POST+GET parameters together,
-            # resulting in a signature mismatch. By removing the QUERY_STRING before
-            # validating the request, the library will generate the signature based only on
-            # the POST parameters like Canvas.
-            qs = request.META.pop('QUERY_STRING', '')
-            self.logger.debug('removed query string temporarily: %s' % qs)
-            request_is_valid = tool_provider.is_valid_request(validator)
-            request.META['QUERY_STRING'] = qs  # restore the query string
-            self.logger.debug('restored query string: %s' % request.META['QUERY_STRING'])
-        except oauth2.Error as e:
+        # NOTE: before validating the request, temporarily remove the
+        # QUERY_STRING to work around an issue with how Canvas signs requests
+        # that contain GET parameters. Before Canvas launches the tool, it duplicates the GET
+        # parameters as POST parameters, and signs the POST parameters (*not* the GET parameters).
+        # However, the oauth2 library that validates the request generates
+        # the oauth signature based on the combination of POST+GET parameters together,
+        # resulting in a signature mismatch. By removing the QUERY_STRING before
+        # validating the request, the library will generate the signature based only on
+        # the POST parameters like Canvas.
+        #
+        # 03feb20 naomi: TODO check if removing query string still needed,
+        # since change to pylti/lti which uses oauthlib. It looks like oauthlib
+        # correctly disregards query string in
+        # oauthlib/oauth1/rfc5849/signature:base_string_uri()
+        # -- could not force a query string in unit tests using django.test.Client
+        qs = request.META.pop('QUERY_STRING', '')
+        self.logger.debug('removed query string temporarily: %s' % qs)
+        request_is_valid = tool_provider.is_valid_request(validator)
+        request.META['QUERY_STRING'] = qs  # restore the query string
+        self.logger.debug('restored query string: %s' % request.META['QUERY_STRING'])
+
+        if not request_is_valid:
             self.logger.error("signature check failed")
-            self.logger.exception(e)
-            raise LTILaunchError('Authorization Error')
+            raise PermissionDenied
 
         self.logger.info("signature verified")
-
-        self.logger.debug("about to check the timestamp: %d" % int(tool_provider.oauth_timestamp))
-        if time.time() - int(tool_provider.oauth_timestamp) > 60 * 60:
-            self.logger.warning("OAuth timestamp is too old.")
-            # raise PermissionDenied
-        else:
-            self.logger.info("OAuth timestamp looks good")
 
         for required_param in ('resource_link_id', 'context_id', 'user_id'):
             if required_param not in request.POST:
@@ -350,7 +372,7 @@ class MultiLTILaunchMiddleware(MiddlewareMixin):
         request.session['LOGGED_IP'] = logged_ip
         self.logger.info("LTI launch IP address logged: %s" % logged_ip)
 
-    def _set_current_session(self, request, resource_link_id=None, raise_exception=False):
+    def _set_current_session(self, request, resource_link_id=None):
         '''
          Sets the current session on the request object based on the given resource_link_id.
          The current session is available via the 'LTI' attribute on the request (e.g. request.LTI).

--- a/annotationsx/middleware.py
+++ b/annotationsx/middleware.py
@@ -15,15 +15,13 @@ load the iframe.
 import collections
 
 from django.conf import settings
-from django.core.exceptions import PermissionDenied, ImproperlyConfigured
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.http import HttpResponseBadRequest
 from lti.contrib.django import DjangoToolProvider
 import logging
-import time
 import json
 import importlib
-import oauth2
 
 from .lti_validators import LTIRequestValidator
 
@@ -145,7 +143,7 @@ class ContentSecurityPolicyMiddleware(MiddlewareMixin):
 
 class CookielessSessionMiddleware(MiddlewareMixin):
     '''
-    This middleware implements cookieless sessions by retrieving the session identifier 
+    This middleware implements cookieless sessions by retrieving the session identifier
     from  cookies (preferred, if available) or the request URL.
 
     This must be added to INSTALLED_APPS prior to other middleware that uses the session.
@@ -216,7 +214,7 @@ class MultiLTILaunchMiddleware(MiddlewareMixin):
         # when moving to django2 and replacing MIDDLEWARE_CLASSES to MIDDLEWARE in
         # settings, the behavior of exceptions in middleware changed:
         # https://docs.djangoproject.com/en/2.2/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
-        # "Under MIDDLEWARE_CLASSES, process_exception is applied to exceptions raised from a middleware 
+        # "Under MIDDLEWARE_CLASSES, process_exception is applied to exceptions raised from a middleware
         # process_request method. Under MIDDLEWARE, process_exception applies only
         # to exceptions raised from the view."
         #
@@ -253,7 +251,7 @@ class MultiLTILaunchMiddleware(MiddlewareMixin):
         consumer_key = getattr(settings, 'CONSUMER_KEY', None)
         try:
             secret = settings.LTI_SECRET_DICT[request.POST.get('context_id')]
-        except:
+        except Exception:
             secret = settings.LTI_SECRET
 
         if consumer_key is None or secret is None:
@@ -321,7 +319,7 @@ class MultiLTILaunchMiddleware(MiddlewareMixin):
 
     def _update_session(self, request):
         '''
-        Updates the session with the current LTI launch request. There may be multiple LTI launches associated with a 
+        Updates the session with the current LTI launch request. There may be multiple LTI launches associated with a
         single session. Each LTI launch is mapped to its POST parameters using the resource_link_id as the key.
 
         Example:

--- a/annotationsx/requirements/base.txt
+++ b/annotationsx/requirements/base.txt
@@ -8,10 +8,8 @@ django-extensions==2.1.6
 djangorestframework==3.9.2
 httplib2==0.12.1
 idna==2.8
-#git+https://github.com/lduarte1991/ims_lti_py@hx
 lti==0.9.3
 lxml==4.3.3
-git+https://github.com/i-kiwamu/python3-oauth2
 psycopg2-binary==2.8.2
 PyJWT==1.7.1
 python-dateutil==2.8.0

--- a/annotationsx/requirements/test.txt
+++ b/annotationsx/requirements/test.txt
@@ -1,1 +1,5 @@
 -r base.txt
+
+pytest
+pytest-django
+

--- a/annotationsx/settings/local.py
+++ b/annotationsx/settings/local.py
@@ -1,1 +1,24 @@
 from .base import *
+
+ORGANIZATION = 'HARVARDX'
+
+# django secret must not be empty
+SECRET_KEY = 'SECRET'
+
+# local db is sqlite3
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'hxat-test-sqlite3.db'),
+    },
+}
+
+# test lti consumer keys
+CONSUMER_KEY='stark'
+LTI_SECRET='winter is coming'
+TEST_COURSE='coursex'
+TEST_COURSE_LTI_SECRET='coursex_secret'
+LTI_SECRET_DICT = {
+        TEST_COURSE: TEST_COURSE_LTI_SECRET,
+        }
+

--- a/annotationsx/settings/local.py
+++ b/annotationsx/settings/local.py
@@ -14,10 +14,10 @@ DATABASES = {
 }
 
 # test lti consumer keys
-CONSUMER_KEY='stark'
-LTI_SECRET='winter is coming'
-TEST_COURSE='coursex'
-TEST_COURSE_LTI_SECRET='coursex_secret'
+CONSUMER_KEY = 'stark'
+LTI_SECRET = 'winter is coming'
+TEST_COURSE = 'coursex'
+TEST_COURSE_LTI_SECRET = 'coursex_secret'
 LTI_SECRET_DICT = {
         TEST_COURSE: TEST_COURSE_LTI_SECRET,
         }

--- a/annotationsx/settings/test.py
+++ b/annotationsx/settings/test.py
@@ -15,10 +15,10 @@ DATABASES = {
 }
 
 # test lti consumer keys
-CONSUMER_KEY='consumer_key_for_test'
-LTI_SECRET='lti_secret_for_test'
-TEST_COURSE='test_course'
-TEST_COURSE_LTI_SECRET='lti_secret_for_test_course'
+CONSUMER_KEY = 'consumer_key_for_test'
+LTI_SECRET = 'lti_secret_for_test'
+TEST_COURSE = 'test_course'
+TEST_COURSE_LTI_SECRET = 'lti_secret_for_test_course'
 LTI_SECRET_DICT = {
         TEST_COURSE: TEST_COURSE_LTI_SECRET,
         }

--- a/annotationsx/settings/test.py
+++ b/annotationsx/settings/test.py
@@ -1,1 +1,25 @@
 from .base import *
+
+# for harvardx tests
+ORGANIZATION = 'HARVARDX'
+
+# django secret must not be empty
+SECRET_KEY = 'SECRET'
+
+# test db is sqlite3
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'hxat-test-sqlite3.db'),
+    },
+}
+
+# test lti consumer keys
+CONSUMER_KEY='consumer_key_for_test'
+LTI_SECRET='lti_secret_for_test'
+TEST_COURSE='test_course'
+TEST_COURSE_LTI_SECRET='lti_secret_for_test_course'
+LTI_SECRET_DICT = {
+        TEST_COURSE: TEST_COURSE_LTI_SECRET,
+        }
+

--- a/hx_lti_initializer/templatetags/hx_lti_initializer_extras.py
+++ b/hx_lti_initializer/templatetags/hx_lti_initializer_extras.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from dateutil import tz
 from django import template
 from django.template.defaultfilters import stringfilter
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from re import sub
 
 from hx_lti_assignment.models import Assignment

--- a/hx_lti_initializer/tests/conftest.py
+++ b/hx_lti_initializer/tests/conftest.py
@@ -1,0 +1,64 @@
+
+import pytest
+
+from random import randint
+
+from hx_lti_initializer.models import LTICourse
+from hx_lti_initializer.utils import create_new_user
+
+
+@pytest.fixture(scope='function')
+def anon_learner():
+    user, profile = create_new_user(
+            anon_id='anonymous',
+            username='anon_learner',
+            display_name = 'anon_learner',
+            roles=['Learner'],
+            scope='course123',
+            )
+    return {'user':user, 'profile':profile}
+
+@pytest.fixture(scope='function')
+def random_learner():
+    random_id = randint(0, 65534)
+    random_name = 'user_{}'.format(random_id)
+    display_name = 'User {}'.format(random_id)
+    user, profile = create_new_user(
+            anon_id=random_id,
+            username=random_name,
+            display_name=display_name,
+            roles=['Learner'],
+            scope='course123',
+            )
+    return {'user':user, 'profile':profile}
+
+@pytest.fixture(scope='function')
+def random_instructor():
+    random_id = randint(0, 65534)
+    random_name='user_{}'.format(random_id)
+    user, profile = create_new_user(
+            anon_id=random_id,
+            username=random_name,
+            display_name = random_name,
+            roles=['Instructor'],
+            scope='course123',
+            )
+    return {'user':user, 'profile':profile}
+
+@pytest.fixture(scope='function')
+def random_course_instructor():
+    random_id = randint(0, 65534)
+    random_name = 'user_{}'.format(random_id)
+    random_course = 'harvardX+ABC+{}'.format(randint(0, 65534))
+    user, profile = create_new_user(
+            anon_id=random_id,
+            username=random_name,
+            display_name = random_name,
+            roles=['Instructor'],
+            scope='course123',
+            )
+
+    course = LTICourse.create_course(random_course, profile)
+
+    return {'user':user, 'profile':profile, 'course': course}
+

--- a/hx_lti_initializer/tests/conftest.py
+++ b/hx_lti_initializer/tests/conftest.py
@@ -12,11 +12,12 @@ def anon_learner():
     user, profile = create_new_user(
             anon_id='anonymous',
             username='anon_learner',
-            display_name = 'anon_learner',
+            display_name='anon_learner',
             roles=['Learner'],
             scope='course123',
             )
-    return {'user':user, 'profile':profile}
+    return {'user': user, 'profile': profile}
+
 
 @pytest.fixture(scope='function')
 def random_learner():
@@ -30,20 +31,22 @@ def random_learner():
             roles=['Learner'],
             scope='course123',
             )
-    return {'user':user, 'profile':profile}
+    return {'user': user, 'profile': profile}
+
 
 @pytest.fixture(scope='function')
 def random_instructor():
     random_id = randint(0, 65534)
-    random_name='user_{}'.format(random_id)
+    random_name = 'user_{}'.format(random_id)
     user, profile = create_new_user(
             anon_id=random_id,
             username=random_name,
-            display_name = random_name,
+            display_name=random_name,
             roles=['Instructor'],
             scope='course123',
             )
-    return {'user':user, 'profile':profile}
+    return {'user': user, 'profile': profile}
+
 
 @pytest.fixture(scope='function')
 def random_course_instructor():
@@ -53,12 +56,12 @@ def random_course_instructor():
     user, profile = create_new_user(
             anon_id=random_id,
             username=random_name,
-            display_name = random_name,
+            display_name=random_name,
             roles=['Instructor'],
             scope='course123',
             )
 
     course = LTICourse.create_course(random_course, profile)
 
-    return {'user':user, 'profile':profile, 'course': course}
+    return {'user': user, 'profile': profile, 'course': course}
 

--- a/hx_lti_initializer/tests/test_launch.py
+++ b/hx_lti_initializer/tests/test_launch.py
@@ -1,0 +1,371 @@
+#
+# run these with pytest:
+# $> DJANGO_SETTINGS_MODULE=annotationsx.settings.test pytest hx_lti_initializer/tests/test_launch.py  -v
+#
+import pytest
+
+from lti import ToolConsumer
+from random import randint
+from urllib.parse import quote_plus
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import Client
+from django.urls import reverse
+
+from hx_lti_initializer.models import LTICourse
+from hx_lti_initializer.models import LTIProfile
+from .conftest import random_instructor
+
+
+old_timestamp = '1580487110'
+
+@pytest.mark.django_db
+def test_launchLti_session_ok(random_course_instructor):
+    instructor = random_course_instructor['profile']
+    course = random_course_instructor['course']
+    target_path = reverse('hx_lti_initializer:launch_lti')
+    launch_url = 'http://testserver{}'.format(target_path)
+    resource_link_id = 'some_string_to_be_the_fake_resource_link_id'
+    consumer = ToolConsumer(
+            consumer_key=settings.CONSUMER_KEY,
+            consumer_secret=settings.LTI_SECRET,
+            launch_url=launch_url,
+            params={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': resource_link_id,
+                'lis_person_sourcedid': instructor.name,
+                'lis_outcome_service_url': 'fake_url',
+                'user_id': instructor.anon_id,
+                'roles': ['Instructor', 'Administrator'],
+                'context_id': course.course_id,
+                },
+            )
+    params = consumer.generate_launch_data()
+
+    client = Client(enforce_csrf_checks=False)
+    response = client.post(
+            target_path,
+            data=params,
+            )
+    assert(response.status_code == 200)
+    assert(response.cookies.get('sessionid'))
+
+    # check some info in session
+    assert(client.session is not None)
+    assert(client.session.get('LTI_LAUNCH').get(resource_link_id).get('launch_params'))
+    launch_params = client.session.get('LTI_LAUNCH').get(resource_link_id).get('launch_params')
+    assert(launch_params.get('resource_link_id') == resource_link_id)
+    assert(launch_params.get('context_id') == course.course_id)
+    assert(launch_params.get('lis_person_sourcedid') == instructor.name)
+    assert(launch_params.get('oauth_consumer_key') == settings.CONSUMER_KEY)
+
+    # this will not print if test successful
+    for key in launch_params.keys():
+        print('************ launch_params: {} = {}'.format( key, launch_params.get(key)))
+
+    for key in client.session.keys():
+        print('************ SESSION: {} = {}'.format(key, client.session.get(key)))
+
+    session_lti = client.session.get('LTI_LAUNCH', None)
+    assert(session_lti is not None)
+    for key in session_lti.keys():
+        print('************ session LTI: {} = {}'.format(key, session_lti.get(key)))
+
+    lti_params = session_lti[resource_link_id]
+    assert(lti_params is not None)
+    for key in lti_params.keys():
+        print('************ LTI params: {} = {}'.format(key, lti_params.get(key)))
+
+    # forces error to print above messages!
+    #assert(response.context == 'hey')
+
+
+@pytest.mark.django_db
+def test_launchLti_user_course_ok():
+    instructor_name = 'audre_lorde'
+    instructor_edxid = '{}{}'.format(randint(1000,65534), randint(1000, 65534))
+    course_id = 'hx+FancyCourse+TermCode+Year'
+    target_path = reverse('hx_lti_initializer:launch_lti')
+    launch_url = 'http://testserver{}'.format(target_path)
+    resource_link_id = 'some_string_to_be_the_fake_resource_link_id'
+    consumer = ToolConsumer(
+            consumer_key=settings.CONSUMER_KEY,
+            consumer_secret=settings.LTI_SECRET,
+            launch_url=launch_url,
+            params={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': resource_link_id,
+                'lis_person_sourcedid': instructor_name,
+                'lis_outcome_service_url': 'fake_url',
+                'user_id': instructor_edxid,
+                'roles': ['Instructor', 'Administrator'],
+                #'roles': ['Learner'],
+                'context_id': course_id,
+                # 04feb20 naomi: context_title has to do with edx studio not
+                # sending user_id in launch params.
+                'context_title': '{}+title'.format(course_id),
+                },
+            )
+    params = consumer.generate_launch_data()
+
+    client = Client(enforce_csrf_checks=False)
+    response = client.post(
+            target_path,
+            data=params,
+            )
+    assert(response.status_code == 200)
+    assert(response.cookies.get('sessionid'))
+
+    # check user was created
+    user = User.objects.get(username=instructor_name)
+    assert(user is not None)
+    lti_profile = LTIProfile.objects.get(anon_id=instructor_edxid)
+    assert(lti_profile is not None)
+    assert(lti_profile.user.username == user.username)
+
+    # check course was created
+    course = LTICourse.get_course_by_id(course_id)
+    assert(course is not None)
+    assert(len(LTICourse.get_all_courses()) == 1)
+    assert(course.course_admins.all()[0].anon_id == instructor_edxid)
+
+
+@pytest.mark.django_db
+def test_launchLti_expired_timestamp(random_course_instructor):
+    instructor = random_course_instructor['profile']
+    course = random_course_instructor['course']
+    target_path = '/lti_init/launch_lti/'
+    launch_url='http://testserver{}'.format(target_path)
+    consumer = ToolConsumer(
+            consumer_key=settings.CONSUMER_KEY,
+            consumer_secret=settings.LTI_SECRET,
+            launch_url=launch_url,
+            params={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': 'FakeResourceLinkID',
+                'lis_person_sourcedid': instructor.name,
+                'lis_outcome_service_url': 'fake_url',
+                'user_id': instructor.anon_id,
+                'roles': ['Instructor'],
+                'context_id': course.course_id,
+                },
+            )
+    params = consumer.generate_launch_data()
+    #replace for old timestamp
+    params['oauth_timestamp'] = old_timestamp
+
+    client = Client(enforce_csrf_checks=False)
+    response = client.post(
+            target_path,
+            data=params,
+            )
+    assert(response.status_code == 403)
+
+
+@pytest.mark.django_db
+def test_launchLti_unknown_consumer(random_course_instructor):
+    instructor = random_course_instructor['profile']
+    course = random_course_instructor['course']
+    target_path = '/lti_init/launch_lti/'
+    launch_url='http://testserver{}'.format(target_path)
+    consumer = ToolConsumer(
+            consumer_key='stark',
+            consumer_secret='winter is coming',
+            launch_url=launch_url,
+            params={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': 'FakeResourceLinkID',
+                'lis_person_sourcedid': instructor.name,
+                'lis_outcome_service_url': 'fake_url',
+                'user_id': instructor.anon_id,
+                'roles': ['Instructor'],
+                'context_id': course.course_id,
+                },
+            )
+    params = consumer.generate_launch_data()
+
+    client = Client(enforce_csrf_checks=False)
+    response = client.post(
+            target_path,
+            data=params,
+            )
+    assert(response.status_code == 403)
+
+@pytest.mark.django_db
+def test_launchLti_missing_consumer(random_course_instructor):
+    instructor = random_course_instructor['profile']
+    course = random_course_instructor['course']
+    target_path = '/lti_init/launch_lti/'
+    launch_url='http://testserver{}'.format(target_path)
+    consumer = ToolConsumer(
+            consumer_key=settings.CONSUMER_KEY,
+            consumer_secret=settings.LTI_SECRET,
+            launch_url=launch_url,
+            params={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': 'FakeResourceLinkID',
+                'lis_person_sourcedid': instructor.name,
+                'lis_outcome_service_url': 'fake_url',
+                'user_id': instructor.anon_id,
+                'roles': ['Instructor'],
+                'context_id': course.course_id,
+                },
+            )
+    params = consumer.generate_launch_data()
+    del(params['oauth_consumer_key'])  # remove consumer_key
+
+    client = Client(enforce_csrf_checks=False)
+    response = client.post(
+            target_path,
+            data=params,
+            )
+    assert(response.status_code == 403)
+
+@pytest.mark.django_db
+def test_launchLti_missing_required_param(random_course_instructor):
+    instructor = random_course_instructor['profile']
+    course = random_course_instructor['course']
+    target_path = '/lti_init/launch_lti/'
+    launch_url='http://testserver{}'.format(target_path)
+    consumer = ToolConsumer(
+            consumer_key=settings.CONSUMER_KEY,
+            consumer_secret=settings.LTI_SECRET,
+            launch_url=launch_url,
+            params={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': 'FakeResourceLinkID',
+                #'lis_person_sourcedid': instructor.name,
+                'lis_outcome_service_url': 'fake_url',
+                'user_id': instructor.anon_id,
+                'roles': ['Instructor'],
+                'context_id': course.course_id,
+                },
+            )
+    params = consumer.generate_launch_data()
+    client = Client(enforce_csrf_checks=False)
+    response = client.post(
+            target_path,
+            data=params,
+            )
+
+    assert(response.status_code == 400)
+
+@pytest.mark.django_db
+def test_launchLti_switch_consumer(random_course_instructor):
+    instructor = random_course_instructor['profile']
+    course = random_course_instructor['course']
+    target_path = '/lti_init/launch_lti/'
+    launch_url='http://testserver{}'.format(target_path)
+    consumer = ToolConsumer(
+            consumer_key=settings.CONSUMER_KEY,
+            consumer_secret=settings.LTI_SECRET,
+            launch_url=launch_url,
+            params={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': 'FakeResourceLinkID',
+                'lis_person_sourcedid': instructor.name,
+                'lis_outcome_service_url': 'fake_url',
+                'user_id': instructor.anon_id,
+                'roles': ['Instructor'],
+                'context_id': course.course_id,
+                },
+            )
+    params = consumer.generate_launch_data()
+    params['oauth_consumer_key'] = 'switched_consumer_key'
+
+    client = Client(enforce_csrf_checks=False)
+    response = client.post(
+            target_path,
+            data=params,
+            )
+
+    assert(response.status_code == 403)
+
+#
+# TODO: not able to force a query string using django.test.Client
+# debug messages in oauthlib/oauth1/rfc5849/signature.py:verify_hmac_sha1()
+# prints request.uri with clear query strings...
+#
+@pytest.mark.skip
+@pytest.mark.django_db
+def test_launchLti_with_query_string(random_course_instructor):
+    instructor = random_course_instructor['profile']
+    course = random_course_instructor['course']
+    target_path = '/lti_init/launch_lti/'
+    launch_url='http://testserver{}?extra_param=blah&more_args=bloft'.format(target_path)
+    print('mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm launch_url: {}'.format(launch_url))
+    consumer = ToolConsumer(
+            consumer_key=settings.CONSUMER_KEY,
+            consumer_secret=settings.LTI_SECRET,
+            launch_url=launch_url,
+            params={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': 'FakeResourceLinkID',
+                'lis_person_sourcedid': instructor.name,
+                'lis_outcome_service_url': 'fake_url',
+                'user_id': instructor.anon_id,
+                'roles': ['Instructor'],
+                'context_id': course.course_id,
+                },
+            )
+    params = consumer.generate_launch_data()
+    print('mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm lti params: {}'.format(params))
+    req = consumer.generate_launch_request()
+
+    client = Client(enforce_csrf_checks=False)
+    response = client.post(
+            target_path,
+            data=params,
+            )
+
+    print('mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm response content: {}'.format(response.content))
+    assert(response.status_code == 403)
+    assert(response.content == 'hey')
+
+
+
+
+@pytest.mark.skip
+@pytest.mark.django_db
+def test_launchLti(random_course_instructor):
+    instructor = random_course_instructor['profile']
+    course = random_course_instructor['course']
+    target_path = '/lti_init/launch_lti/'
+    launch_url='http://testserver{}'.format(target_path)
+    consumer = ToolConsumer(
+            consumer_key=settings.CONSUMER_KEY,
+            consumer_secret=settings.LTI_SECRET,
+            launch_url=launch_url,
+            params={
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': 'FakeResourceLinkID',
+                'lis_person_sourcedid': instructor.name,
+                'lis_outcome_service_url': 'fake_url',
+                'user_id': instructor.anon_id,
+                'roles': ['Instructor'],
+                'context_id': course.course_id,
+                },
+            )
+    params = consumer.generate_launch_data()
+    #replace for old timestamp
+    params['oauth_timestamp'] = old_timestamp
+
+    client = Client(enforce_csrf_checks=False)
+    response = client.post(
+            target_path,
+            data=params,
+            )
+
+    assert(response.status_code == 403)
+    assert(response.content == 'hey')

--- a/hx_lti_initializer/tests/test_models.py
+++ b/hx_lti_initializer/tests/test_models.py
@@ -8,7 +8,6 @@ from .conftest import random_instructor
 from .conftest import random_learner
 
 
-
 @pytest.mark.django_db
 def test_LTIProfile_create(random_instructor):
     """

--- a/hx_lti_initializer/tests/test_models.py
+++ b/hx_lti_initializer/tests/test_models.py
@@ -1,0 +1,91 @@
+import pytest
+
+
+from hx_lti_initializer.models import LTICourse
+from hx_lti_initializer.models import LTIProfile
+
+from .conftest import random_instructor
+from .conftest import random_learner
+
+
+
+@pytest.mark.django_db
+def test_LTIProfile_create(random_instructor):
+    """
+    Checks that an LTIProfile object was automatically created
+    as soon as a user object was created in setup.
+    """
+    instructor = LTIProfile.objects.get(user=random_instructor['user'])
+
+    assert(isinstance(instructor, LTIProfile))
+    assert(instructor.__unicode__() == instructor.user.username)
+
+
+@pytest.mark.django_db
+def test_LTICourse_create_course(random_instructor):
+    """
+    Checks that you can make a course given a course id and an instructor
+    """
+    instructor = random_instructor['profile']
+
+    course_object = LTICourse.create_course('test_course_id', instructor)
+    assert(isinstance(course_object, LTICourse))
+    assert(course_object.__unicode__() == course_object.course_name)
+
+
+@pytest.mark.django_db
+def test_LTICourse_get_course_by_id(random_instructor):
+    """
+    Checks that you can get a course given an id.
+    """
+    instructor = random_instructor['profile']
+    course_object = LTICourse.create_course('test_course_id', instructor)
+    course_to_test = LTICourse.get_course_by_id('test_course_id')
+
+    assert(isinstance(course_to_test, LTICourse))
+    assert(course_object == course_to_test)
+    assert(course_to_test.course_id == 'test_course_id')
+
+
+@pytest.mark.django_db
+def test_LTICourse_get_courses_of_admin(random_instructor):
+    """
+    Checks that it returns a list of all the courses for that admin.
+    """
+    instructor = random_instructor['profile']
+
+    course_object = LTICourse.create_course('test_course_id', instructor)
+    list_of_courses = LTICourse.get_courses_of_admin(instructor)
+    assert(isinstance(list_of_courses, list))
+    assert(len(list_of_courses) == 1)
+    assert(course_object in list_of_courses)
+
+    course_object2 = LTICourse.create_course('test_course_id2', instructor)
+    list_of_courses2 = LTICourse.get_courses_of_admin(instructor)
+    assert(len(list_of_courses2) == 2)
+    assert(course_object2 in list_of_courses2)
+
+
+@pytest.mark.django_db
+def test_LTICourse_get_all_courses(random_instructor, random_learner):
+    """
+    Checks that all courses are returned regardless of admin user
+    """
+    instructor1 = LTIProfile.objects.get(user_id=random_instructor['user'].pk)
+    instructor2 = LTIProfile.objects.get(user_id=random_learner['user'].pk)
+
+    list_of_courses = LTICourse.get_all_courses()
+    assert(isinstance(list_of_courses, list))
+    assert(len(list_of_courses) == 0)
+
+    LTICourse.create_course('test_course_id', instructor1)
+    list_of_courses2 = LTICourse.get_all_courses()
+    assert(isinstance(list_of_courses2, list))
+    assert(len(list_of_courses2) == 1)
+
+    LTICourse.create_course('test_course_id2', instructor2)
+    list_of_courses3 = LTICourse.get_all_courses()
+    assert(isinstance(list_of_courses3, list))
+    assert(len(list_of_courses3) == 2)
+
+

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -100,7 +100,7 @@ def launch_lti(request):
             display_name = lti_profile.user.username
             messages.warning(request, "edX still has not fixed issue with no user_id in studio.")
             messages.error(request, "Warning: you are logged in as a Preview user. Please view this in live to access admin hub.")
-        except:
+        except Exception:
             logger.debug('DEBUG - username not found in post.')
             raise PermissionDenied('username not found in LTI launch')
     logger.debug("DEBUG - user name: " + display_name)
@@ -162,7 +162,7 @@ def launch_lti(request):
         )
 
     except LTICourse.DoesNotExist:
-        logger.debug('DEBUG - Course %s was NOT found. Will be created.' %course)
+        logger.debug( 'DEBUG - Course {} was NOT found. Will be created.'.format(course))
 
         # Put a message on the screen to indicate to the user that the course doesn't exist
         message_error = "Sorry, the course you are trying to reach does not exist."
@@ -213,7 +213,7 @@ def launch_lti(request):
                 course_object.add_admin(lti_profile)
                 logger.info("CourseAdmin Pending found: %s" % userfound)
                 userfound.delete()
-            except:
+            except Exception:
                 logger.info("Not waiting to be added as admin")
         logger.debug("DEBUG - User wants to go directly to annotations for a specific target object using UI")
         return access_annotation_target(request, course_id, assignment_id, object_id)
@@ -223,8 +223,8 @@ def launch_lti(request):
         LTIResourceLinkConfig.objects.filter(resource_link_id=resource_link_id).delete()
         logger.info('Proceed to the admin hub.')
     except PermissionDenied as e:
-        raise e # make sure to re-raise this exception since we shouldn't proceed
-    except:
+        raise e  # make sure to re-raise this exception since we shouldn't proceed
+    except Exception as e:
         # For the use case where the course head wants to display an assignment object instead
         # of the admin_hub upon launch (i.e. for embedded use), this allows the user
         # to be routed directly to an assignment given the correct POST parameters,
@@ -247,13 +247,13 @@ def launch_lti(request):
                     course_object.add_admin(lti_profile)
                     logger.info("CourseAdmin Pending found: %s" % userfound)
                     userfound.delete()
-                except:
+                except Exception:
                     logger.info("Not waiting to be added as admin")
                 return course_admin_hub(request)
             else:
                 logger.debug("DEBUG - User wants to go directly to annotations for a specific target object")
                 return access_annotation_target(request, course_id, assignment_id, object_id)
-        except:
+        except Exception:
             logger.debug("DEBUG - User wants the index")
 
     try:
@@ -264,7 +264,7 @@ def launch_lti(request):
         course_object.add_admin(lti_profile)
         logger.info("CourseAdmin Pending found: %s" % userfound)
         userfound.delete()
-    except:
+    except Exception:
         logger.debug("DEBUG - Not waiting to be added as admin")
 
     return course_admin_hub(request)
@@ -301,7 +301,7 @@ def edit_course(request, id):
                                 new_admin_course_id=course.course_id
                             )
                             new_course_admin.save()
-                        except:
+                        except Exception:
                             # admin already pending
                             logger.info("Admin already pending.")
 
@@ -318,7 +318,7 @@ def edit_course(request, id):
 
     try:
         pending_admins = LTICourseAdmin.objects.filter(new_admin_course_id=course.course_id)
-    except:
+    except Exception:
         pending_admins = None
 
     return render(
@@ -351,7 +351,7 @@ def course_admin_hub(request):
         to = TargetObject.objects.get(pk=object_id)
         starter_object = to.target_title
 
-    except:
+    except Exception:
         object_id = None
         collection_id = None
         to = None
@@ -401,7 +401,7 @@ def access_annotation_target(
         raise AnnotationTargetDoesNotExist('Assignment or target object does not exist')
     try:
         is_instructor = request.LTI['is_staff']
-    except:
+    except Exception:
         is_instructor = False
 
     if not is_instructor and not assignment.is_published:
@@ -409,7 +409,7 @@ def access_annotation_target(
 
     try:
         hide_sidebar = request.LTI['launch_params']['custom_hide_sidebar_instance'].split(',')
-    except:
+    except Exception:
         hide_sidebar = []
 
     save_session(request, collection_id=assignment_id, object_id=object_id, object_uri=object_uri, context_id=course_id)
@@ -530,6 +530,7 @@ def instructor_dashboard_view(request):
     }
     return render(request, 'hx_lti_initializer/dashboard_view.html', context)
 
+
 def instructor_dashboard_student_list_view(request):
     '''
     Renders the student annotations for the instructor dashboard.
@@ -558,6 +559,7 @@ def instructor_dashboard_student_list_view(request):
     }
     return render(request, 'hx_lti_initializer/dashboard_student_list_view.html', context)
 
+
 def error_view(request, message):
     '''
     Implements graceful and user-friendly (also debugger-friendly) error displays
@@ -582,7 +584,7 @@ def delete_assignment(request):
         assignment = Assignment.objects.get(assignment_id=collection_id)
         assignment.delete()
         logger.debug("DEBUG - Assignment Deleted: " + unicode(assignment))
-    except:
+    except Exception:
         return error_view(request, "The assignment deletion may have failed")
 
     url = reverse('hx_lti_initializer:course_admin_hub') + '?resource_link_id=%s' % request.LTI['resource_link_id']
@@ -611,7 +613,7 @@ def change_starting_resource(request, assignment_id, object_id):
             config.object_id = object_id
             config.save()
             data['response'] = 'Success: Updated'
-        except:
+        except Exception:
             newConfig = LTIResourceLinkConfig(resource_link_id=resource_link_id, collection_id=assignment_id, object_id=object_id)
             newConfig.save()
             data['response'] = 'Success: Created'


### PR DESCRIPTION
Security fix for lti authentication of signature: test return value instead of expect an exception when signature invalid.

@arthurian I don't think I've changed the lti-launch behavior too drastically, but didn't really tested with canvas!

Added some tests via pytests for lti-launch.