### PR TITLE
hx iss95: missing tool_consumer_instance_guid in lti-params

### DIFF
--- a/annotation_store/store.py
+++ b/annotation_store/store.py
@@ -604,8 +604,9 @@ class WebAnnotationStoreBackend(StoreBackend):
             self.logger.error("requested timed out!")
             return self._response_timeout()
         self.logger.info('update response status_code=%s' % response.status_code)
+
         if response.status_code == 200:
-            cleaned_annotation = json.loads(response.content)
+            cleaned_annotation = json.loads(response.content.decode())
             self.send_annotation_notification('annotation_updated', cleaned_annotation)
         return HttpResponse(response.content, status=response.status_code, content_type='application/json')
 
@@ -619,7 +620,7 @@ class WebAnnotationStoreBackend(StoreBackend):
             return self._response_timeout()
         self.logger.info('delete response status_code=%s' % response.status_code)
         if response.status_code == 200:
-            cleaned_annotation = json.loads(response.content)
+            cleaned_annotation = json.loads(response.content.decode())
             self.send_annotation_notification('annotation_deleted', cleaned_annotation)
         return HttpResponse(response)
 

--- a/annotationsx/lti_validators.py
+++ b/annotationsx/lti_validators.py
@@ -67,8 +67,7 @@ class LTIRequestValidator(RequestValidator):
             secret = to_unicode(settings.LTI_SECRET_DICT[context_id])
         except KeyError:  # context_id not in LTI_SECRET_DICT
             if client_key == settings.CONSUMER_KEY:
-                log.error('----------------- lti({} -- {}):'.format(
-                    client_key, to_unicode(settings.LTI_SECRET)))
+                log.error('----------------- lti consumer key FALLBACK')
                 return to_unicode(settings.LTI_SECRET)
             else:  # oauth_consumer_key not a known value
                 log.error(
@@ -76,8 +75,6 @@ class LTIRequestValidator(RequestValidator):
                             client_key))
                 return self.dummy_secret
         else:  # all went well
-            log.error('--------------*** lti({} -- {}):'.format(
-                client_key, to_unicode(settings.LTI_SECRET)))
             return secret
 
 

--- a/tests/annotation_store/test_store_views.py
+++ b/tests/annotation_store/test_store_views.py
@@ -36,12 +36,10 @@ def test_api_root_default_ok(
 
     # 2. set starting resource
     resource_link_id = launch_params['resource_link_id']
-    resource_config = LTIResourceLinkConfig(
-            resource_link_id=resource_link_id,
-            collection_id=assignment.assignment_id,
-            object_id=target_object.id,
-            )
-    resource_config.save()
+    resource_config = LTIResourceLinkConfig.objects.create(
+        resource_link_id=resource_link_id,
+        assignment_target=assignment_target,
+    )
 
     # 3. lti launch
     client = Client(enforce_csrf_checks=False)
@@ -155,14 +153,12 @@ def test_api_root_default_no_starting_resource(
     assignment = assignment_target.assignment
     assignment.save()
 
-    # 2. no starting resource
+    # 2. set starting resource
     #resource_link_id = launch_params['resource_link_id']
-    #resource_config = LTIResourceLinkConfig(
-    #        resource_link_id=resource_link_id,
-    #        collection_id=assignment.assignment_id,
-    #        object_id=target_object.id,
-    #        )
-    #resource_config.save()
+    #resource_config = LTIResourceLinkConfig.objects.create(
+    #    resource_link_id=resource_link_id,
+    #    assignment_target=assignment_target,
+    #)
 
     # 3. lti launch
     client = Client(enforce_csrf_checks=False)
@@ -201,12 +197,10 @@ def test_api_root_backend_from_request_ok(
 
     # 2. set starting resource
     resource_link_id = launch_params['resource_link_id']
-    resource_config = LTIResourceLinkConfig(
-            resource_link_id=resource_link_id,
-            collection_id=assignment.assignment_id,
-            object_id=target_object.id,
-            )
-    resource_config.save()
+    resource_config = LTIResourceLinkConfig.objects.create(
+        resource_link_id=resource_link_id,
+        assignment_target=assignment_target,
+    )
 
     # 3. lti launch
     client = Client(enforce_csrf_checks=False)
@@ -280,7 +274,8 @@ def test_api_root_backend_from_request_ok(
     assert content == annojs
 
     # update request
-    path_with_id = '{}/{}?version=catchpy'.format(path, annojs_id)
+    path_with_id = '{}/{}?version=catchpy&resource_link_id={}'.format(
+            path, annojs_id, resource_link_id)
     response = client.put(
             path_with_id,
             data=annojs,
@@ -288,10 +283,10 @@ def test_api_root_backend_from_request_ok(
             HTTP_X_ANNOTATOR_AUTH_TOKEN=jwt_token,
             )
     assert response.status_code == 200
+
     content = json.loads(response.content.decode())
     assert len(responses.calls) == 3
     assert content == annojs
-
 
     # delete request
     response = client.delete(
@@ -328,12 +323,10 @@ def test_api_root_backend_from_request_store_cfg_from_db_ok(
 
     # 2. set starting resource
     resource_link_id = launch_params['resource_link_id']
-    resource_config = LTIResourceLinkConfig(
-            resource_link_id=resource_link_id,
-            collection_id=assignment.assignment_id,
-            object_id=target_object.id,
-            )
-    resource_config.save()
+    resource_config = LTIResourceLinkConfig.objects.create(
+        resource_link_id=resource_link_id,
+        assignment_target=assignment_target,
+    )
 
     # 3. lti launch
     client = Client(enforce_csrf_checks=False)
@@ -361,7 +354,8 @@ def test_api_root_backend_from_request_store_cfg_from_db_ok(
 
     annotation_store_urls = {}
     for op in ['search']:  # search preserve params request to hxat
-        annotation_store_urls[op] = '{}/?version=catchpy&collectionId={}&resource_link_id={}'.format(
+        annotation_store_urls[op] = \
+            '{}/?version=catchpy&collectionId={}&resource_link_id={}'.format(
                 assignment.annotation_database_url,
                 assignment.assignment_id,
                 resource_link_id,
@@ -401,7 +395,8 @@ def test_api_root_backend_from_request_store_cfg_from_db_ok(
     assert content == annojs
 
     # update request
-    path_with_id = '{}/{}?version=catchpy'.format(path, annojs_id)
+    path_with_id = '{}/{}?version=catchpy&resource_link_id={}'.format(
+            path, annojs_id, resource_link_id)
     response = client.put(
             path_with_id,
             data=annojs,
@@ -414,8 +409,8 @@ def test_api_root_backend_from_request_store_cfg_from_db_ok(
     assert content == annojs
 
     # delete request
-    path_delete = '{}/{}?version=catchpy&collectionId={}'.format(
-            path, annojs_id, assignment.assignment_id)
+    path_delete = '{}/{}?version=catchpy&collectionId={}&resource_link_id={}'.format(
+            path, annojs_id, assignment.assignment_id, resource_link_id)
 
     response = client.delete(
             path_delete,
@@ -471,12 +466,10 @@ def test_api_root_webanno_grade_ok(
 
     # 2. set starting resource
     resource_link_id = launch_params['resource_link_id']
-    resource_config = LTIResourceLinkConfig(
-            resource_link_id=resource_link_id,
-            collection_id=assignment.assignment_id,
-            object_id=target_object.id,
-            )
-    resource_config.save()
+    resource_config = LTIResourceLinkConfig.objects.create(
+        resource_link_id=resource_link_id,
+        assignment_target=assignment_target,
+    )
 
     # 3. lti launch
     client = Client(enforce_csrf_checks=False)
@@ -554,7 +547,8 @@ def test_api_root_webanno_grade_ok(
     assert content == annojs
 
     # update request
-    path_with_id = '{}/{}?version=catchpy'.format(path, annojs_id)
+    path_with_id = '{}/{}?version=catchpy&resource_link_id={}'.format(
+            path, annojs_id, resource_link_id)
     response = client.put(
             path_with_id,
             data=annojs,
@@ -567,8 +561,8 @@ def test_api_root_webanno_grade_ok(
     assert content == annojs
 
     # delete request
-    path_delete = '{}/{}?version=catchpy&collectionId={}'.format(
-            path, annojs_id, assignment.assignment_id)
+    path_delete = '{}/{}?version=catchpy&collectionId={}&resource_link_id={}'.format(
+            path, annojs_id, assignment.assignment_id, resource_link_id)
 
     response = client.delete(
             path_delete,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ def lti_launch_params_factory():
             with_grade=False,
             consumer_key=None,
             consumer_secret=None,
+            tool_consumer_instance_guid=None,
             ):
         params={
             'lti_message_type': 'basic-lti-launch-request',
@@ -155,6 +156,8 @@ def lti_launch_params_factory():
         if with_grade:
             params['lis_outcome_service_url'] = 'http://fake_url.com/'
             params['lis_result_sourcedid'] = '{}:{}:123'.format(course_id, resource_link_id)
+        if tool_consumer_instance_guid:
+            params['tool_consumer_instance_guid'] = tool_consumer_instance_guid
 
         consumer = ToolConsumer(
                 consumer_key=consumer_key if consumer_key else settings.CONSUMER_KEY,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,12 +52,11 @@ def course_instructor_factory(user_profile_factory):
 @pytest.fixture
 def assignment_target_factory():
     def _assignment_target_factory(course):
-        target_object = TargetObject(
+        target_object = TargetObject.objects.create(
                 target_title='{} Title'.format(uuid.uuid4().hex),
                 target_author='John {}'.format(uuid.uuid4().int),
                 )
-        target_object.save()
-        assignment = Assignment(
+        assignment = Assignment.objects.create(
                 course=course,
                 assignment_name='Assignment {}'.format(uuid.uuid4().hex),
                 pagination_limit=settings.ANNOTATION_PAGINATION_LIMIT_DEFAULT,
@@ -66,13 +65,11 @@ def assignment_target_factory():
                 annotation_database_apikey = settings.ANNOTATION_DB_API_KEY,
                 annotation_database_secret_token = settings.ANNOTATION_DB_SECRET_TOKEN,
         )
-        assignment.save()
-        assignment_target = AssignmentTargets(
+        assignment_target = AssignmentTargets.objects.create(
                 assignment=assignment,
                 target_object=target_object,
                 order=1,
                 )
-        assignment_target.save()
         return assignment_target
 
     return _assignment_target_factory


### PR DESCRIPTION
This fixes issue #95.

When hxat is configured with settings.ORGANIZATION != HARVARDX, it is tacitly assumed to be working with canvas platform/consumer and expects the tool_consumer_instance_id to be sent in lti_params. This is used to distinguish the user_scope a user_id has: edx platform/consumer (HARVARDX) assigns a anonymous-id for a user in each course while canvas assigns the same user-id across all courses for a user. The user-scope is set to "course:<course-id>" for edx and "consumer:<tool_consumer_instance_id>" for canvas. This fix aims to have a default user_scope for when settings.ORGANIZATION != HARVARDX and the platform/consumer does not send the tool_consumer_instance_id, defaulting to user_scope "course:<course-id>".

This hxat settings is somewhat mislabeled since the HARVARDX might have to work in the future with platform/consumers that do not send a tool_consumer_instance_id (this is an optional lti-param) and have user_scope to be across courses. This setting and its behavior should be reviewed in the future.