### PR TITLE
atg-sync: fixed image upload error

### DIFF
--- a/image_store/backends.py
+++ b/image_store/backends.py
@@ -87,7 +87,8 @@ class IMMImageStoreBackend(ImageStoreBackend):
             # authenticate and ensure course space exists
             self.client.authenticate(user_id=self.user_id)
             course = self.client.find_or_create_course(**self.course_attrs)
-            logger.info("User %s loaded course: %s" % (self.user_id, course))
+            self.client.authenticate(user_id=self.user_id, course_id=course['id'], course_permission='write')
+            logger.info("User %s authenticated to course: %s" % (self.user_id, course))
 
             # upload image to the course space
             course_images = self.client.api.upload_images(


### PR DESCRIPTION
This PR fixes an image upload error that was discovered in today's Canvas testing by ensuring that the user is granted `write` access when the token is requested.

@nmaekawa 