### PR TITLE
Daphne + SSL + WhiteNoise for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![Build Status](https://travis-ci.org/Harvard-ATG/annotationsx.svg?branch=master)
 ![Coverage Status](./coverage.svg)
 
 # The HarvardX Annotation Tool (HxAT)
@@ -14,6 +13,7 @@ Requirements:
 
 - Python 3.6+ 
 - Postgresql 9.6+
+- [ASGI](https://asgi.readthedocs.io/en/latest/) application server such as [Daphne](http://github.com/django/daphne).
 
 ### Quickstart
 
@@ -28,6 +28,17 @@ $ ./manage.py runserver
 Notes:
 - You will need to create a postgres database first (e.g. `createdb hxat`).
 - You will need to edit `secure.py` to configure the database connection details.
+- The `runserver` command will automatically start daphne (ASGI server), which will handle HTTP and websocket requests. 
+
+### Running Django with SSL
+
+Generate a certificate for local development using a tool such as [mkcert](https://github.com/FiloSottile/mkcert) and then start the server:
+
+```
+$ daphne -e ssl:8000:privateKey=key.pem:certKey=cert.pem annotationsx.asgi:application
+```
+
+Note: The reason we need to run daphne directly is that at the time of writing, the django `runserver` command doesn't support SSL and `runsslserver` (via [django-sslserver](https://github.com/teddziuba/django-sslserver)) doesn't support ASGI/Daphne. 
 
 ## LMS Integration
 

--- a/annotationsx/requirements/base.txt
+++ b/annotationsx/requirements/base.txt
@@ -8,7 +8,6 @@ django-braces==1.14.0
 django-cookies-samesite==0.8.0
 django-crispy-forms==1.9.0
 django-extensions==2.2.8
-django-sslserver==0.22
 djangorestframework==3.11.0
 httplib2==0.18.0
 lti==0.9.5
@@ -18,4 +17,5 @@ python-dateutil==2.8.1
 pytz==2019.3
 requests==2.23.0
 python_dotenv==0.14.0
+WhiteNoise==5.2.0
 git+https://github.com/Harvard-ATG/media_management_sdk.git@v0.1.0#egg=media_management_sdk==0.1.0

--- a/annotationsx/settings/base.py
+++ b/annotationsx/settings/base.py
@@ -65,7 +65,6 @@ INSTALLED_APPS = (
     "django_extensions",
     "bootstrap3",
     "crispy_forms",
-    "sslserver",
     "hx_lti_initializer",
     "annotation_store",
     "hx_lti_assignment",
@@ -80,6 +79,7 @@ MIDDLEWARE = (
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "annotationsx.middleware.ContentSecurityPolicyMiddleware",
     "annotationsx.middleware.MultiLTILaunchMiddleware",
     #'annotationsx.middleware.SessionMiddleware',
@@ -394,3 +394,4 @@ HXAT_NOTIFY_ERRORLOG = os.environ.get("HXAT_NOTIFY_ERRORLOG", "false").lower() =
 
 # time-to-live for ws auth
 WS_JWT_TTL = os.environ.get("WS_JWT_TTL", 300)
+

--- a/annotationsx/settings/secure.py.example
+++ b/annotationsx/settings/secure.py.example
@@ -17,7 +17,7 @@ SECURE_SETTINGS = {
     'db_default_user': 'annotationsx',
     'db_default_password': 'password',
     'db_default_host': 'localhost',
-    'annotation_database_url': 'http://localhost:8080/catch/annotator',
+    'annotation_database_url': 'http://localhost:8080/annos',
     'annotation_db_api_key': '49a70e80-3c06-11e7-a919-92ebcb67fe33',
     'annotation_db_secret_token': 'bd79cd1c-3c06-11e7-a919-92ebcb67fe33',
     'accessibility': True

--- a/hx_lti_initializer/templates/ig/detail_hxighlighter.html
+++ b/hx_lti_initializer/templates/ig/detail_hxighlighter.html
@@ -42,7 +42,7 @@ Text Annotation Tool | {{ target_object.target_title }}
                     </details>
                     <button id='ma-button' class="make-annotation-button btn btn-default">Make Annotation</button>
 
-                    
+
                     <div id="hx-sr-notifications" class='sr-only' aria-live="assertive">
                         <div class='sr-real-alert'></div>
                         <div class="sr-alert"></div>
@@ -162,7 +162,7 @@ Text Annotation Tool | {{ target_object.target_title }}
                     Badges: {
                     },
 	            Websockets: {
-                        wsUrl: window.location.hostname,
+                        wsUrl: window.location.hostname + (window.location.port ? ":"+window.location.port : ""),
 			utm: "{{ utm_source }}",
 		        resource: "{{ resource_link_id }}"
                     },
@@ -171,7 +171,7 @@ Text Annotation Tool | {{ target_object.target_title }}
                         homeURL: "{% url 'hx_lti_initializer:course_admin_hub' %}?resource_link_id={{ resource_link_id }}&utm_source={{utm_source}}",
                         has_staff_permissions: ("{{ is_instructor }}" === "True")
                         {% endif %}
-                    },  
+                    },
                     PrevNextButton: {
                         prevUrl: {% if prev_object %}"{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=prev_object.target_object.id %}?utm_source={{utm_source}}&resource_link_id={{resource_link_id}}" {% else %} "" {% endif %},
                         nextUrl: {% if next_object %}"{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=next_object.target_object.id %}?utm_source={{utm_source}}&resource_link_id={{resource_link_id}}" {% else %} "" {% endif %},

--- a/hx_lti_initializer/templates/tx/detail_hxighlighter.html
+++ b/hx_lti_initializer/templates/tx/detail_hxighlighter.html
@@ -44,7 +44,7 @@ Text Annotation Tool | {{ target_object.target_title }}
                     </details>
                     <button id='ma-button' class="make-annotation-button btn btn-default">Make Annotation</button>
 
-                    
+
                     <div id="hx-sr-notifications" class='sr-only' aria-live="polite">
                         <div class='sr-real-alert'></div>
                         <div class="sr-alert"></div>
@@ -162,7 +162,7 @@ Text Annotation Tool | {{ target_object.target_title }}
                     Badges: {
                     },
                     Websockets: {
-                        wsUrl: window.location.hostname,
+                        wsUrl: window.location.hostname + (window.location.port ? ":"+window.location.port : ""),
                         utm: "{{ utm_source }}",
                         resource: "{{ resource_link_id }}"
                     },
@@ -171,7 +171,7 @@ Text Annotation Tool | {{ target_object.target_title }}
                         homeURL: "{% url 'hx_lti_initializer:course_admin_hub' %}?resource_link_id={{ resource_link_id }}&utm_source={{utm_source}}",
                         has_staff_permissions: ("{{ is_instructor }}" === "True")
                         {% endif %}
-                    },  
+                    },
                     PrevNextButton: {
                         prevUrl: {% if prev_object %}"{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=prev_object.target_object.id %}?utm_source={{utm_source}}&resource_link_id={{resource_link_id}}" {% else %} "" {% endif %},
                         nextUrl: {% if next_object %}"{% url 'hx_lti_initializer:access_annotation_target' course_id=course assignment_id=collection object_id=next_object.target_object.id %}?utm_source={{utm_source}}&resource_link_id={{resource_link_id}}" {% else %} "" {% endif %},


### PR DESCRIPTION
This PR adds support for running an SSL development server using Daphne + WhiteNoise.

**Changes:**
- Removes `django-sslserver`.
- Adds [WhiteNoise](http://whitenoise.evans.io/) to `MIDDLEWARE` in order to serve staticfiles.
- Updates `wsUrl` config value in text and image hxighlighter templates so that the port number is included in the websocket URL. 
- Updates README with details on running Daphne with SSL.

**Additional Notes:**

The problem this PR is solving is that `django-sslserver` does not support ASGI/Daphne, and while the default `runserver` command does support ASGI/Daphne, it does not support SSL (or at least it does not provide a way to configure daphne -- which would obviate the need for this PR). 

One way to handle this is to run 2 processes: daphne to handle websocket requests, and `django-sslserver` to handle everything else, including static files. For example:

```
$ ./manage.py runsslserver --key key.pem --certificate cert.pem 127.0.0.1:8000
$ daphne -e ssl:8001:privateKey=key.pem:certKey=cert.pem annotationsx.asgi:application
```

But when we do this, we also have to configure the `wsUrl` in the hxighlighter templates to point to a different port than the main application. It would be simpler if we could have daphne handle everything, including staticfiles:

```
$ daphne -e ssl:8000:privateKey=key.pem:certKey=cert.pem annotationsx.asgi:application
```

This is the approach taken by the PR. If there's a better way, definitely open to it!

@nmaekawa Thoughts?