### PR TITLE
Allow zero or more course admins

### DIFF
--- a/hx_lti_initializer/admin.py
+++ b/hx_lti_initializer/admin.py
@@ -7,7 +7,7 @@ throughout the LTI. Even courses is only related via the target objects.
 
 from django.contrib import admin
 from django.contrib.sessions.models import Session
-from hx_lti_initializer.models import LTICourse, LTIProfile, LTIResourceLinkConfig
+from hx_lti_initializer.models import LTICourse, LTICourseAdmin, LTIProfile, LTIResourceLinkConfig
 
 
 class LTIProfileAdmin(admin.ModelAdmin):
@@ -16,7 +16,7 @@ class LTIProfileAdmin(admin.ModelAdmin):
     ordering = ("user", "scope", "anon_id", "name", "roles")
 
 
-class LTICourseAdmin(admin.ModelAdmin):
+class LTICourseListAdmin(admin.ModelAdmin):
     list_display = (
         "course_name",
         "course_id",
@@ -47,7 +47,12 @@ class SessionAdmin(admin.ModelAdmin):
     list_display = ["session_key", "_session_data", "expire_date"]
 
 
+class LTIPendingAdmin(admin.ModelAdmin):
+    list_display = ("admin_unique_identifier", "new_admin_course_id")
+
+
 admin.site.register(Session, SessionAdmin)
 admin.site.register(LTIProfile, LTIProfileAdmin)
-admin.site.register(LTICourse, LTICourseAdmin)
+admin.site.register(LTICourse, LTICourseListAdmin)
 admin.site.register(LTIResourceLinkConfig, LTIResourceLinkConfigAdmin)
+admin.site.register(LTICourseAdmin, LTIPendingAdmin)

--- a/hx_lti_initializer/models.py
+++ b/hx_lti_initializer/models.py
@@ -73,7 +73,7 @@ class LTICourse(models.Model):
 
     # admins are able to add other users with LTIProfiles already in the system
     course_admins = models.ManyToManyField(
-        LTIProfile, related_name="course_admin_user_profiles",
+        LTIProfile, related_name="course_admin_user_profiles", blank=True,
     )
 
     course_users = models.ManyToManyField(

--- a/hx_lti_initializer/urls.py
+++ b/hx_lti_initializer/urls.py
@@ -18,7 +18,7 @@ from hx_lti_initializer.views import (
 )
 
 urlpatterns = [
-    path("course/(<int:id>)/edit/", edit_course, name="edit_course",),
+    path("course/<int:id>/edit/", edit_course, name="edit_course",),
     path("launch_lti/", launch_lti, name="launch_lti",),
     path("admin_hub/", course_admin_hub, name="course_admin_hub",),
     path(

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -398,8 +398,6 @@ def edit_course(request, id):
                 request.LTI["resource_link_id"], request.session.session_key
             )
             return redirect(url)
-        else:
-            raise PermissionDenied("Invalid course form submitted")
     else:
         form = CourseForm(instance=course, user_scope=user_scope)
 


### PR DESCRIPTION
This PR modifies `LTICourse.course_admins` so that it is no longer a required field when editing a course.

The motivation for this change is to allow the following workflow:
1. Course support staff installs the LTI tool in the course and launches the tool to set things up, which creates the `LTICourse` and adds them as an admin by default.
2. Course support staff finishes setting up the annotation assignment(s) and then removes himself/herself from the list of course admins and adds the real instructor to the list of pending admins, so that when that instructor logs in they become the course admin.

Previously, trying to remove yourself from the list of course admins would result in a _403 Forbidden_, but this error should no longer occur when `course_admins` is empty. If an error does occur, the user should now see a form error message rather than a generic 403.

@nmaekawa 