### PR TITLE
upgrade django 3.2

### DIFF
--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment2.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 {% load extra_options %}
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap3 %}
 {% bootstrap_javascript %}
 

--- a/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment_hxighlighter.html
+++ b/hx_lti_assignment/templates/hx_lti_assignment/create_new_assignment_hxighlighter.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 {% load extra_options %}
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap3 %}
 {% bootstrap_javascript %}
 

--- a/hx_lti_assignment/views.py
+++ b/hx_lti_assignment/views.py
@@ -9,7 +9,7 @@ from django.contrib.auth.decorators import login_required
 from django.core import serializers
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, QueryDict
-from django.shortcuts import get_object_or_404, redirect, render, render_to_response
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from hx_lti_assignment.forms import (
     AssignmentForm,

--- a/hx_lti_initializer/apps.py
+++ b/hx_lti_initializer/apps.py
@@ -5,9 +5,9 @@ by Luis Duarte, HarvardX
 This file purely exists to give the app the name "Courses and Instructors"
 in the admin panel instead of "hx_lti_initializer".
 """
-
+# Update depreciated ugettext_lazy to gettext_lazy https://docs.djangoproject.com/en/3.0/releases/3.0/#id3
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class InitializerConfig(AppConfig):

--- a/hx_lti_initializer/models.py
+++ b/hx_lti_initializer/models.py
@@ -10,8 +10,8 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.functions import Lower
 from django.db.models.signals import post_save
-from django.utils.translation import ugettext_lazy as _
-
+from django.utils.translation import gettext_lazy as _
+# Update depreciated ugettext_lazy to gettext_lazy https://docs.djangoproject.com/en/3.0/releases/3.0/#id3
 
 class LTIProfile(models.Model):
     """

--- a/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/annotation_base.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         {% block beginningscripts %}{% endblock %}
-        {% load staticfiles %}
+        {% load static %}
         {% load list_of_ids %}
         {# Load the tag library #}
         {% load bootstrap3 %}

--- a/hx_lti_initializer/templates/hx_lti_initializer/base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/base.html
@@ -3,7 +3,7 @@
 <html lang="en">
     <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    {% load staticfiles %}
+    {% load static %}
     {% load hx_lti_initializer_extras %}
     <link rel="stylesheet" href="{% static "vendors/development/css/font-awesome.css" %}">
     <link rel="stylesheet" type="text/css" href="{% static "vendors/development/css/bootstrap-select.css" %}">

--- a/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/dashboard_view.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/base.html' %}
 {% load hx_lti_initializer_extras %}
-{% load static from staticfiles %} 
+{% load static from static %} 
 {# Load the tag library #} 
 {% load bootstrap3 %} 
 {# Load CSS and JavaScript #} 

--- a/hx_lti_initializer/templates/hx_lti_initializer/embed_lti_selection.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/embed_lti_selection.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap3 %}
 <!DOCTYPE html>
 <html lang="en">

--- a/hx_lti_initializer/templates/hx_lti_initializer/hxighlighter_base.html
+++ b/hx_lti_initializer/templates/hx_lti_initializer/hxighlighter_base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        {% load staticfiles %}
+        {% load static %}
         {% load list_of_ids %}
         {# Load the tag library #}
         {% load hx_lti_initializer_extras %}

--- a/hx_lti_initializer/templates/ig/detail.html
+++ b/hx_lti_initializer/templates/ig/detail.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/annotation_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 {% block beginningscripts %}
 <script src="{% static "vendors/development/jquery-1.9.1.js" %}"></script>

--- a/hx_lti_initializer/templates/ig/detail_hxighlighter.html
+++ b/hx_lti_initializer/templates/ig/detail_hxighlighter.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/hxighlighter_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 
 {% block title %}

--- a/hx_lti_initializer/templates/tx/detail.html
+++ b/hx_lti_initializer/templates/tx/detail.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/annotation_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 {% block beginningscripts %}
 <script src="{% static "vendors/development/jquery-1.12.4.js" %}"></script>

--- a/hx_lti_initializer/templates/tx/detail_hxighlighter.html
+++ b/hx_lti_initializer/templates/tx/detail_hxighlighter.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/hxighlighter_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 
 {% block title %}

--- a/hx_lti_initializer/templates/vd/detail.html
+++ b/hx_lti_initializer/templates/vd/detail.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/annotation_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 
 {% block beginningscripts %}

--- a/hx_lti_initializer/templates/vd/detail_hxighlighter.html
+++ b/hx_lti_initializer/templates/vd/detail_hxighlighter.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/hxighlighter_base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load list_of_ids %}
 
 {% block title %}

--- a/hx_lti_initializer/views.py
+++ b/hx_lti_initializer/views.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.core.exceptions import MultipleObjectsReturned, PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render

--- a/hxat/asgi.py
+++ b/hxat/asgi.py
@@ -5,16 +5,32 @@ defined in the ASGI_APPLICATION setting
 import os
 
 import django
-from channels.routing import get_default_application
+import notification.routing
+from django.conf.urls import url
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.http import AsgiHandler
 from dotenv import load_dotenv
 
 # default settings_module is prod
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hxat.settings.prod")
-
+os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+django.setup()
+# move below django.setup() due to django exception: django.core.exceptions.ImproperlyConfigured
+from notification.middleware import SessionAuthMiddleware
 # if dotenv file, load it
 dotenv_path = os.environ.get("HXAT_DOTENV_PATH", None)
 if dotenv_path:
     load_dotenv(dotenv_path=dotenv_path, override=True)
 
-django.setup()
-application = get_default_application()
+# application = get_default_application()
+django_asgi_app = AsgiHandler()
+
+application = ProtocolTypeRouter(
+    {
+        # Explicitly set 'http' key using Django's ASGI application.
+        "https": django_asgi_app,
+        "websocket": SessionAuthMiddleware(
+            URLRouter(notification.routing.websocket_urlpatterns)
+        ),
+    }
+)

--- a/hxat/asgi.py
+++ b/hxat/asgi.py
@@ -5,31 +5,16 @@ defined in the ASGI_APPLICATION setting
 import os
 
 import django
-import notification.routing
-from django.conf.urls import url
-from channels.routing import ProtocolTypeRouter, URLRouter
-from channels.http import AsgiHandler
+from channels.routing import get_default_application
 from dotenv import load_dotenv
 
 # default settings_module is prod
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hxat.settings.prod")
-django.setup()
-# move below django.setup() due to django exception: django.core.exceptions.ImproperlyConfigured
-from notification.middleware import SessionAuthMiddleware
+
 # if dotenv file, load it
 dotenv_path = os.environ.get("HXAT_DOTENV_PATH", None)
 if dotenv_path:
     load_dotenv(dotenv_path=dotenv_path, override=True)
 
-# application = get_default_application()
-django_asgi_app = AsgiHandler()
-
-application = ProtocolTypeRouter(
-    {
-        # Explicitly set 'http' key using Django's ASGI application.
-        "https": django_asgi_app,
-        "websocket": SessionAuthMiddleware(
-            URLRouter(notification.routing.websocket_urlpatterns)
-        ),
-    }
-)
+django.setup()
+application = get_default_application()

--- a/hxat/asgi.py
+++ b/hxat/asgi.py
@@ -13,7 +13,6 @@ from dotenv import load_dotenv
 
 # default settings_module is prod
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hxat.settings.prod")
-os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 django.setup()
 # move below django.setup() due to django exception: django.core.exceptions.ImproperlyConfigured
 from notification.middleware import SessionAuthMiddleware

--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==2.2.13
+Django==3.0.0
 channels==2.4.0
 channels_redis==2.4.2
 coverage==5.0

--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -1,5 +1,5 @@
 Django~=3.2.0
-channels==2.4.0
+channels~=3.0.4
 channels_redis==2.4.2
 coverage==5.0
 coverage-badge==1.0.1

--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==3.0.0
+Django~=3.0.0
 channels==2.4.0
 channels_redis==2.4.2
 coverage==5.0

--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -1,11 +1,10 @@
-Django~=3.0.0
+Django~=3.1.0
 channels==2.4.0
 channels_redis==2.4.2
 coverage==5.0
 coverage-badge==1.0.1
 django-bootstrap3==12.0.3
 django-braces==1.14.0
-django-cookies-samesite==0.8.0
 django-crispy-forms==1.9.0
 django-extensions==2.2.8
 djangorestframework==3.11.0

--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -1,4 +1,4 @@
-Django~=3.1.0
+Django~=3.2.0
 channels==2.4.0
 channels_redis==2.4.2
 coverage==5.0

--- a/hxat/requirements/base.txt
+++ b/hxat/requirements/base.txt
@@ -1,6 +1,6 @@
 Django~=3.2.0
 channels~=3.0.4
-channels_redis==2.4.2
+channels_redis==3.3.0
 coverage==5.0
 coverage-badge==1.0.1
 django-bootstrap3==12.0.3

--- a/hxat/routing.py
+++ b/hxat/routing.py
@@ -1,14 +1,14 @@
-import notification.routing
-from channels.routing import ProtocolTypeRouter, URLRouter
-from notification.middleware import SessionAuthMiddleware
+# import notification.routing
+# from channels.routing import ProtocolTypeRouter, URLRouter
+# from notification.middleware import SessionAuthMiddleware
 
-ASGI_APPLICATION = "hxat.routing.application"
+# ASGI_APPLICATION = "hxat.routing.application"
 
-application = ProtocolTypeRouter(
-    {
-        # (http->django views is added by default)
-        "websocket": SessionAuthMiddleware(
-            URLRouter(notification.routing.websocket_urlpatterns)
-        ),
-    }
-)
+# application = ProtocolTypeRouter(
+#     {
+#         # (http->django views is added by default)
+#         "websocket": SessionAuthMiddleware(
+#             URLRouter(notification.routing.websocket_urlpatterns)
+#         ),
+#     }
+# )

--- a/hxat/routing.py
+++ b/hxat/routing.py
@@ -1,14 +1,18 @@
-# import notification.routing
-# from channels.routing import ProtocolTypeRouter, URLRouter
-# from notification.middleware import SessionAuthMiddleware
+import notification.routing
+from channels.routing import ProtocolTypeRouter, URLRouter
+from notification.middleware import SessionAuthMiddleware
+from channels.http import AsgiHandler
 
-# ASGI_APPLICATION = "hxat.routing.application"
+ASGI_APPLICATION = "hxat.routing.application"
 
-# application = ProtocolTypeRouter(
-#     {
-#         # (http->django views is added by default)
-#         "websocket": SessionAuthMiddleware(
-#             URLRouter(notification.routing.websocket_urlpatterns)
-#         ),
-#     }
-# )
+django_asgi_app = AsgiHandler()
+
+application = ProtocolTypeRouter(
+    {
+        # Explicitly set 'http' key using Django's ASGI application.
+        "https": django_asgi_app,
+        "websocket": SessionAuthMiddleware(
+            URLRouter(notification.routing.websocket_urlpatterns)
+        ),
+    }
+)

--- a/hxat/settings/base.py
+++ b/hxat/settings/base.py
@@ -92,7 +92,9 @@ WSGI_APPLICATION = "hxat.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        # django.db.backends.postgresql_psycopg2 module is deprecated in favor of django.db.backends.postgresq
+        # https://docs.djangoproject.com/en/3.0/releases/2.0/#id1
+        "ENGINE": "django.db.backends.postgresql",
         "NAME": os.environ.get(
             "HXAT_DB_NAME", SECURE_SETTINGS.get("db_default_name", "annotationsx")
         ),

--- a/hxat/settings/base.py
+++ b/hxat/settings/base.py
@@ -373,7 +373,7 @@ elif ORGANIZATION == "HARVARDX":
     pass
 
 # channels for notification
-ASGI_APPLICATION = "hxat.asgi.application"
+ASGI_APPLICATION = "hxat.routing.application"
 REDIS_HOST = os.environ.get(
     "REDIS_HOST", SECURE_SETTINGS.get("redis_host", "localhost")
 )

--- a/hxat/settings/base.py
+++ b/hxat/settings/base.py
@@ -72,7 +72,6 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = (
-    "django_cookies_samesite.middleware.CookiesSameSite",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "hxat.middleware.CookielessSessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -350,10 +349,10 @@ IMAGE_STORE_BACKEND_CONFIG = os.environ.get(
     "IMAGE_STORE_BACKEND_CONFIG", SECURE_SETTINGS.get("image_store_backend_config", "")
 )
 
-# replace when django 3.1, see https://github.com/jotes/django-cookies-samesite
+# https://docs.djangoproject.com/en/3.2/releases/3.1/#django-contrib-sessions
 # due to chrome 80.X, see https://www.chromium.org/updates/same-site
-DCS_SESSION_COOKIE_SAMESITE = "None"
-DCS_CSRF_COOKIE_SAMESITE = "None"
+SESSION_COOKIE_SAMESITE = "None"
+CSRF_COOKIE_SAMESITE = "None"
 
 if ANNOTATION_HTTPS_ONLY:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/hxat/settings/base.py
+++ b/hxat/settings/base.py
@@ -389,3 +389,5 @@ HXAT_NOTIFY_ERRORLOG = os.environ.get("HXAT_NOTIFY_ERRORLOG", "false").lower() =
 # time-to-live for ws auth
 WS_JWT_TTL = os.environ.get("WS_JWT_TTL", 300)
 
+# https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/hxat/settings/base.py
+++ b/hxat/settings/base.py
@@ -373,7 +373,7 @@ elif ORGANIZATION == "HARVARDX":
     pass
 
 # channels for notification
-ASGI_APPLICATION = "hxat.routing.application"
+ASGI_APPLICATION = "hxat.asgi.application"
 REDIS_HOST = os.environ.get(
     "REDIS_HOST", SECURE_SETTINGS.get("redis_host", "localhost")
 )

--- a/hxat/settings/secure.py.example
+++ b/hxat/settings/secure.py.example
@@ -2,6 +2,8 @@
 # Using the below secure settings in combination with project defaults should be 
 # sufficient to get you started.  Make sure you copy this file over as is to
 # secure.py before running `vagrant up`.
+# Note: 'https_only': True required to create/delete assignments when running locally
+    
 
 SECURE_SETTINGS = {
     'django_secret_key': 'SuPeR-SeCrEt_KeY!',
@@ -20,6 +22,7 @@ SECURE_SETTINGS = {
     'annotation_database_url': 'http://localhost:8080/annos',
     'annotation_db_api_key': '49a70e80-3c06-11e7-a919-92ebcb67fe33',
     'annotation_db_secret_token': 'bd79cd1c-3c06-11e7-a919-92ebcb67fe33',
-    'accessibility': True
+    'accessibility': True,
+    'https_only': True
 }
 

--- a/notification/middleware.py
+++ b/notification/middleware.py
@@ -6,9 +6,6 @@ from urllib.parse import parse_qs
 from django.conf import settings
 from django.contrib.sessions.models import Session
 from django.db import close_old_connections
-import os
-
-os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 

--- a/notification/middleware.py
+++ b/notification/middleware.py
@@ -6,6 +6,9 @@ from urllib.parse import parse_qs
 from django.conf import settings
 from django.contrib.sessions.models import Session
 from django.db import close_old_connections
+import os
+
+os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 

--- a/notification/middleware.py
+++ b/notification/middleware.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs
 from django.conf import settings
 from django.contrib.sessions.models import Session
 from django.db import close_old_connections
+from asgiref.sync import sync_to_async
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
@@ -13,11 +14,11 @@ SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 class SessionAuthMiddleware(object):
     """auth via session_id in query string."""
 
-    def __init__(self, inner):
-        self.inner = inner
+    def __init__(self, app):
+        self.app = app
         self.log = logging.getLogger(__name__)
 
-    def __call__(self, scope):
+    async def __call__(self, scope, receive, send):
         # not authorized yet
         scope["hxat_auth"] = "403"
         scope["hx_user_id"] = "anonymous"
@@ -34,7 +35,7 @@ class SessionAuthMiddleware(object):
         if not parsed_query:
             scope["hxat_auth"] = "403: missing querystring"
             self.log.debug("NOTIFY {}".format(scope["hxat_auth"]))
-            return self.inner(scope)
+            return await self.app(scope, receive, send)
 
         session_id = parsed_query.get(b"utm_source", [b""])[0].decode()
         resource_link_id = parsed_query.get(b"resource_link_id", [b""])[0].decode()
@@ -44,7 +45,7 @@ class SessionAuthMiddleware(object):
         if not session_id or not resource_link_id:
             scope["hxat_auth"] = "403: missing session-id or resource-link-id"
             self.log.debug("NOTIFY {}".format(scope["hxat_auth"]))
-            return self.inner(scope)
+            return await self.app(scope, receive, send)
 
         # close old db conn to prevent usage of timed out conn
         # see https://channels.readthedocs.io/en/latest/topics/authentication.html#custom-authentication
@@ -90,7 +91,7 @@ class SessionAuthMiddleware(object):
 
         self.log.debug("NOTIFY {}".format(scope["hxat_auth"]))
         self.log.debug("NOTIFY finished with middleware")
-        return self.inner(scope)
+        return await self.app(scope, receive, send)
 
 
 """

--- a/notification/routing.py
+++ b/notification/routing.py
@@ -3,5 +3,5 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
-    re_path(r"^ws/notification/(?P<room_name>[^/]+)/$", consumers.NotificationConsumer),
+    re_path(r"^ws/notification/(?P<room_name>[^/]+)/$", consumers.NotificationConsumer.as_asgi()),
 ]

--- a/target_object_database/templates/target_object_database/source_form.html
+++ b/target_object_database/templates/target_object_database/source_form.html
@@ -1,6 +1,6 @@
 {% extends 'hx_lti_initializer/base.html' %}
 {% load extra_options %}
-{% load staticfiles %}
+{% load static %}
 
 {% block css_file %}
 <style type="text/css">

--- a/target_object_database/views.py
+++ b/target_object_database/views.py
@@ -9,7 +9,6 @@ from django.shortcuts import (  # noqa
     get_object_or_404,
     redirect,
     render,
-    render_to_response,
 )
 from django.urls import reverse
 from django.utils.html import escape


### PR DESCRIPTION
Update django 2.2.13 to 3.2.0
- change `{% load staticfiles %}` to `{% load static %}`
- updated `django.contrib.staticfiles.templatetags.staticfiles` to `django.templatetags.static`
- removed `render_to_response`
- removed `django-cookies-samesite` package in favor of native django 3.1 samesite cookies
- replaced `django.db.backends.postgresql_psycopg2` with `django.db.backends.postgresql`
- replaced `ugettext_lazy ` with `gettext_lazy`
- Upgraded channel to `3.0.4` and [channels_redis](https://pypi.org/project/channels-redis/3.3.0/) to `3.3.0` Note: Redis server will need to be upgraded to >=5 and a redis server will be needed to run locally

Note: Failing test before the django upgrade(tested on master branch with django 2.2.13)

https://github.com/Harvard-ATG/hxat/blob/5770378c105cf00b74558f3773e6ddddaba31f4c/notification/tests/test_consumer.py#L149

https://github.com/Harvard-ATG/hxat/blob/5770378c105cf00b74558f3773e6ddddaba31f4c/notification/tests/test_consumer.py#L89
