### PR TITLE
added conditional to default to standard path for env if HXAT_DOTENV_PATH cannot be found

### DIFF
--- a/hxat/asgi.py
+++ b/hxat/asgi.py
@@ -13,6 +13,10 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hxat.settings.prod")
 
 # if dotenv file, load it
 dotenv_path = os.environ.get("HXAT_DOTENV_PATH", None)
+# defaults to standard path for .env file if dotenv cant be found from environment variable
+if not dotenv_path:
+    if os.path.exists(os.path.join('hxat', 'settings', '.env')):
+        dotenv_path = os.path.join('hxat', 'settings', '.env')
 if dotenv_path:
     load_dotenv(dotenv_path=dotenv_path, override=True)
 


### PR DESCRIPTION
This PR adds a conditional to `asgi.py` to default to standard path(similar to the call in `manage.py`) for `.env` if HXAT_DOTENV_PATH cannot be found in the environment variable. This change is mostly due to how our deployment process/application is ran(e.g. `gunicorn` => `asgi.py`) which bypasses the `manage.py runserver` execution and the path to `.env` is never loaded and passed to the `base.py`.