### PR TITLE
fix use_highlighter to default to true

### DIFF
--- a/hx_lti_assignment/views.py
+++ b/hx_lti_assignment/views.py
@@ -52,6 +52,7 @@ def create_new_assignment(request):
             assignment = None
             if form.is_valid():
                 assignment = form.save(commit=False)
+                # explicitly set to True to use the new hxighlighter UI 
                 assignment.use_hxighlighter = True
                 random_id = uuid.uuid4()
                 assignment.assignment_id = str(random_id)

--- a/hx_lti_assignment/views.py
+++ b/hx_lti_assignment/views.py
@@ -52,6 +52,7 @@ def create_new_assignment(request):
             assignment = None
             if form.is_valid():
                 assignment = form.save(commit=False)
+                assignment.use_hxighlighter = True
                 random_id = uuid.uuid4()
                 assignment.assignment_id = str(random_id)
                 assignment.save()


### PR DESCRIPTION
This PR fixes a bug where newly created assignments would default to the old UI(black background).
- Explicitly set `use_hxighlighter=True` when a new assignment is created