### PR TITLE
Fix for hxighlighter

### DIFF
--- a/hxat/__init__.py
+++ b/hxat/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "6.0.0"  # drop oldui, lti dict as json, drop secure.py
+__version__ = "6.1.0"  # transfer in UI; profile (anon_id, scope) uniq restriction (require catchpy 2.6.0)
 


### PR DESCRIPTION
This PR fixes the `use_hxighlighter` issue where the attribute was  getting set to `false` when the assignment is edited/modified. This change should default the `use_hxighlighter` to `true`